### PR TITLE
Remove stray artifact marker from main coordinator

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -62,8 +62,7 @@ class SystemCoordinator {
       if (isFeatureEnabled('MONTHLY_SUMMARIES')) {
         results.components.monthlySummaries = initializeMonthlySummaries();
       }
- codex/sort-and-merge-code-into-version-6.2
-      
+
       if (isFeatureEnabled('PLAYER_MINUTES_TRACKING')) {
         results.components.playerManagement = initializePlayerManagement();
       }


### PR DESCRIPTION
## Summary
- remove the orphaned artifact marker left between feature toggles in the main coordinator

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d1f1528fc483299150b3ed84200b5b