### PR TITLE
Align module versions with 6.2.0

### DIFF
--- a/src/batch-fixtures.gs
+++ b/src/batch-fixtures.gs
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Enhanced batch posting for fixtures and results with delegated monthly summaries
- * @version 6.2.1
+ * @version 6.2.0
  * @author Senior Software Architect
  * @description Handles batch posting (1–5 fixtures/results), postponed notifications,
  *              and provides idempotent integrations with Make.com. Monthly summaries are delegated.

--- a/src/performance-optimized.gs
+++ b/src/performance-optimized.gs
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Performance Optimization Fixes
- * @version 6.0.1
+ * @version 6.2.0
  * @author Senior Software Architect
  * @description Critical performance improvements and memory leak fixes
  */

--- a/src/security-auth-enhanced.gs
+++ b/src/security-auth-enhanced.gs
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Enhanced Security Manager with Critical Fixes
- * @version 6.0.1
+ * @version 6.2.0
  * @author Senior Software Architect
  * @description SECURITY PATCHES for critical vulnerabilities
  */


### PR DESCRIPTION
## Summary
- update the @version annotation to 6.2.0 across batch fixtures, enhanced security, and performance modules
- confirm no remaining references to earlier 6.x.x versions in those modules

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d2a5ef6f648329b6e57df82876d15b