### PR TITLE
chore: align version annotations to 6.2.0

### DIFF
--- a/src/batch-fixtures.gs
+++ b/src/batch-fixtures.gs
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Enhanced batch posting for fixtures and results with delegated monthly summaries
- * @version 6.2.1
+ * @version 6.2.0
  * @author Senior Software Architect
  * @description Handles batch posting (1–5 fixtures/results), postponed notifications,
  *              and provides idempotent integrations with Make.com. Monthly summaries are delegated.

--- a/src/performance-optimized.gs
+++ b/src/performance-optimized.gs
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Performance Optimization Fixes
- * @version 6.0.1
+ * @version 6.2.0
  * @author Senior Software Architect
  * @description Critical performance improvements and memory leak fixes
  */

--- a/src/security-auth-enhanced.gs
+++ b/src/security-auth-enhanced.gs
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Enhanced Security Manager with Critical Fixes
- * @version 6.0.1
+ * @version 6.2.0
  * @author Senior Software Architect
  * @description SECURITY PATCHES for critical vulnerabilities
  */


### PR DESCRIPTION
## Summary
- update the @version annotation in the batch fixtures, enhanced security, and performance optimization scripts to 6.2.0
- confirm no remaining references to 6.2.1 or 6.0.1 within those files

## Testing
- not run (no automated test or lint scripts documented)

------
https://chatgpt.com/codex/tasks/task_e_68d29c3743788329bfda347d3b626b0e