### PR TITLE
Refine SheetUtils logging and deduplicate methods

### DIFF
--- a/src/utils.gs
+++ b/src/utils.gs
@@ -49,24 +49,17 @@ const SheetUtils = {
    * @returns {GoogleAppsScript.Spreadsheet.Sheet|null} Sheet object or null
    */
   getOrCreateSheet(sheetName, requiredColumns = []) {
-
     const sheetLogger = getSheetLogger();
+    const normalizedColumns = Array.isArray(requiredColumns) ? requiredColumns : [];
+
     sheetLogger.enterFunction('getOrCreateSheet', {
       sheetName,
-      requiredColumnsCount: requiredColumns.length
+      requiredColumnsCount: normalizedColumns.length
     });
 
     let sheet = null;
     let sheetCreated = false;
     let failure = null;
-
-
-    sheetLogger.enterFunction('getOrCreateSheet', {
-      sheetName,
-      requiredColumnsCount: Array.isArray(requiredColumns) ? requiredColumns.length : 0
-    });
-    let sheet = null;
-    let sheetCreated = false;
 
     try {
       const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
@@ -76,52 +69,31 @@ const SheetUtils = {
         sheet = spreadsheet.insertSheet(sheetName);
         sheetCreated = true;
 
-
-        if (requiredColumns.length > 0) {
-
-        if (Array.isArray(requiredColumns) && requiredColumns.length > 0) {
-
-          const headerRange = sheet.getRange(1, 1, 1, requiredColumns.length);
-          headerRange.setValues([requiredColumns]);
+        if (normalizedColumns.length > 0) {
+          const headerRange = sheet.getRange(1, 1, 1, normalizedColumns.length);
+          headerRange.setValues([normalizedColumns]);
           headerRange.setFontWeight('bold');
           headerRange.setBackground('#f0f0f0');
         }
-
-      } else if (requiredColumns.length > 0) {
-        this.ensureColumnsExist(sheet, requiredColumns);
+      } else if (normalizedColumns.length > 0) {
+        this.ensureColumnsExist(sheet, normalizedColumns);
       }
     } catch (error) {
       failure = error;
       sheetLogger.error(`Failed to get or create sheet: ${sheetName}`, {
         sheetName,
+        requiredColumns: normalizedColumns,
         error: error instanceof Error ? { message: error.message, stack: error.stack } : error
-
-      } else if (Array.isArray(requiredColumns) && requiredColumns.length > 0) {
-        this.ensureColumnsExist(sheet, requiredColumns);
-      }
-    } catch (error) {
-      sheetLogger.error(`Failed to get or create sheet: ${sheetName}`, {
-        error,
-        sheetName,
-        requiredColumns
-
       });
       sheet = null;
-    } finally {
-      sheetLogger.exitFunction('getOrCreateSheet', {
-
-        success: sheet !== null,
-        sheetName,
-        sheetCreated,
-        ...(failure ? { errorMessage: failure.message || String(failure) } : {})
-      });
     }
 
-        sheetName,
-        created: sheetCreated,
-        success: !!sheet
-      });
-    }
+    sheetLogger.exitFunction('getOrCreateSheet', {
+      sheetName,
+      created: sheetCreated,
+      success: sheet !== null,
+      ...(failure ? { errorMessage: failure.message || String(failure) } : {})
+    });
 
     return sheet;
   },
@@ -132,36 +104,29 @@ const SheetUtils = {
    * @param {Array<string>} requiredColumns - Required columns
   */
   ensureColumnsExist(sheet, requiredColumns) {
-
     const sheetLogger = getSheetLogger();
     const sheetName = (sheet && typeof sheet.getName === 'function') ? sheet.getName() : 'UnknownSheet';
+    const normalizedColumns = Array.isArray(requiredColumns) ? requiredColumns : [];
 
     sheetLogger.enterFunction('ensureColumnsExist', {
       sheetName,
-      requiredColumnsCount: requiredColumns.length
+      requiredColumnsCount: normalizedColumns.length
     });
 
     let missingColumns = [];
     let failure = null;
 
-
-    sheetLogger.enterFunction('ensureColumnsExist', {
-      sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-      requiredColumnsCount: Array.isArray(requiredColumns) ? requiredColumns.length : 0
-    });
-    let missingColumns = [];
-
     try {
+      if (!sheet || typeof sheet.getLastColumn !== 'function') {
+        throw new Error('Invalid sheet reference provided');
+      }
+
       const lastColumn = sheet.getLastColumn();
-      const currentHeaders = lastColumn > 0 ?
-        sheet.getRange(1, 1, 1, lastColumn).getValues()[0] : [];
+      const currentHeaders = lastColumn > 0
+        ? sheet.getRange(1, 1, 1, lastColumn).getValues()[0]
+        : [];
 
-
-      missingColumns = requiredColumns.filter(col => !currentHeaders.includes(col));
-
-      missingColumns = Array.isArray(requiredColumns) ?
-        requiredColumns.filter(col => !currentHeaders.includes(col)) : [];
-
+      missingColumns = normalizedColumns.filter(col => !currentHeaders.includes(col));
 
       if (missingColumns.length > 0) {
         const startColumn = currentHeaders.length + 1;
@@ -171,30 +136,19 @@ const SheetUtils = {
         range.setBackground('#f0f0f0');
       }
     } catch (error) {
-
       failure = error;
       sheetLogger.error('Failed to ensure columns exist', {
         sheetName,
-        requiredColumns,
+        requiredColumns: normalizedColumns,
         error: error instanceof Error ? { message: error.message, stack: error.stack } : error
       });
-    } finally {
-      sheetLogger.exitFunction('ensureColumnsExist', {
-        sheetName,
-        missingColumnsCount: missingColumns.length,
-        ...(failure ? { errorMessage: failure.message || String(failure) } : {})
-
-      sheetLogger.error('Failed to ensure columns exist', {
-        error,
-        sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-        requiredColumns
-      });
-    } finally {
-      sheetLogger.exitFunction('ensureColumnsExist', {
-        addedColumns: missingColumns
-
-      });
     }
+
+    sheetLogger.exitFunction('ensureColumnsExist', {
+      sheetName,
+      missingColumnsCount: missingColumns.length,
+      ...(failure ? { errorMessage: failure.message || String(failure) } : {})
+    });
   },
 
   /**
@@ -204,7 +158,6 @@ const SheetUtils = {
    * @returns {boolean} Success status
    */
   addRowFromObject(sheet, dataObject) {
-
     const sheetLogger = getSheetLogger();
     const sheetName = (sheet && typeof sheet.getName === 'function') ? sheet.getName() : 'UnknownSheet';
 
@@ -216,49 +169,36 @@ const SheetUtils = {
     let success = false;
     let failure = null;
 
-
-    sheetLogger.enterFunction('addRowFromObject', {
-      sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-      keys: dataObject ? Object.keys(dataObject) : []
-    });
-    let success = false;
-
     try {
-      const headers = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
-      const rowData = headers.map(header => dataObject[header] || '');
+      if (!sheet || typeof sheet.getLastColumn !== 'function') {
+        throw new Error('Invalid sheet reference provided');
+      }
+
+      const lastColumn = sheet.getLastColumn();
+      if (lastColumn === 0) {
+        throw new Error('Cannot add row without headers');
+      }
+
+      const headers = sheet.getRange(1, 1, 1, lastColumn).getValues()[0];
+      const rowData = headers.map(header => (dataObject && Object.prototype.hasOwnProperty.call(dataObject, header)) ? dataObject[header] : '');
 
       const nextRow = sheet.getLastRow() + 1;
       sheet.getRange(nextRow, 1, 1, rowData.length).setValues([rowData]);
       success = true;
     } catch (error) {
-
       failure = error;
       sheetLogger.error('Failed to add row from object', {
         sheetName,
         dataKeys: Object.keys(dataObject || {}),
         error: error instanceof Error ? { message: error.message, stack: error.stack } : error
       });
-    } finally {
-      sheetLogger.exitFunction('addRowFromObject', {
-        sheetName,
-        success,
-        ...(failure ? { errorMessage: failure.message || String(failure) } : {})
-      });
     }
 
-
-      sheetLogger.error('Failed to add row from object', {
-        error,
-        sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-        dataObject
-      });
-      success = false;
-    } finally {
-      sheetLogger.exitFunction('addRowFromObject', {
-        sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-        success
-      });
-    }
+    sheetLogger.exitFunction('addRowFromObject', {
+      sheetName,
+      success,
+      ...(failure ? { errorMessage: failure.message || String(failure) } : {})
+    });
 
     return success;
   },
@@ -270,60 +210,42 @@ const SheetUtils = {
    * @returns {Object|null} Found row object or null
    */
   findRowByCriteria(sheet, criteria) {
-
     const sheetLogger = getSheetLogger();
     const sheetName = (sheet && typeof sheet.getName === 'function') ? sheet.getName() : 'UnknownSheet';
+    const normalizedCriteria = criteria && typeof criteria === 'object' ? criteria : {};
 
     sheetLogger.enterFunction('findRowByCriteria', {
       sheetName,
-      criteriaKeys: Object.keys(criteria || {})
+      criteriaKeys: Object.keys(normalizedCriteria)
     });
 
     let result = null;
     let failure = null;
 
-
-    sheetLogger.enterFunction('findRowByCriteria', {
-      sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-      criteriaKeys: criteria ? Object.keys(criteria) : []
-    });
-    let result = null;
-
     try {
       const data = this.getAllDataAsObjects(sheet);
 
       result = data.find(row => {
-        return Object.keys(criteria).every(key => {
-          return String(row[key]).trim() === String(criteria[key]).trim();
+        return Object.keys(normalizedCriteria).every(key => {
+          return String(row[key]).trim() === String(normalizedCriteria[key]).trim();
         });
       }) || null;
     } catch (error) {
-
       failure = error;
       sheetLogger.error('Failed to find row by criteria', {
         sheetName,
-        criteria,
+        criteria: normalizedCriteria,
         error: error instanceof Error ? { message: error.message, stack: error.stack } : error
-
-      sheetLogger.error('Failed to find row by criteria', {
-        error,
-        sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-        criteria
-
       });
       result = null;
-    } finally {
-      sheetLogger.exitFunction('findRowByCriteria', {
-
-        sheetName,
-        found: result !== null,
-        ...(failure ? { errorMessage: failure.message || String(failure) } : {})
-      });
     }
 
-        found: !!result
-      });
-    }
+    sheetLogger.exitFunction('findRowByCriteria', {
+      sheetName,
+      found: result !== null,
+      ...(failure ? { errorMessage: failure.message || String(failure) } : {})
+    });
+
     return result;
   },
 
@@ -335,40 +257,33 @@ const SheetUtils = {
    * @returns {boolean} Success status
    */
   updateRowByCriteria(sheet, criteria, updates) {
-
     const sheetLogger = getSheetLogger();
     const sheetName = (sheet && typeof sheet.getName === 'function') ? sheet.getName() : 'UnknownSheet';
+    const normalizedCriteria = criteria && typeof criteria === 'object' ? criteria : {};
+    const normalizedUpdates = updates && typeof updates === 'object' ? updates : {};
 
     sheetLogger.enterFunction('updateRowByCriteria', {
       sheetName,
-      criteriaKeys: Object.keys(criteria || {}),
-      updateKeys: Object.keys(updates || {})
+      criteriaKeys: Object.keys(normalizedCriteria),
+      updateKeys: Object.keys(normalizedUpdates)
     });
 
     let success = false;
     let rowsEvaluated = 0;
-    let failure = null;
     let exitReason = 'completed';
-
-
-    sheetLogger.enterFunction('updateRowByCriteria', {
-      sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-      criteriaKeys: criteria ? Object.keys(criteria) : [],
-      updateKeys: updates ? Object.keys(updates) : []
-    });
-    let success = false;
+    let failure = null;
 
     try {
+      if (!sheet || typeof sheet.getLastRow !== 'function') {
+        throw new Error('Invalid sheet reference provided');
+      }
+
       const lastRow = sheet.getLastRow();
       const lastColumn = sheet.getLastColumn();
-
 
       if (lastRow <= 1 || lastColumn === 0) {
         exitReason = 'no_data';
       } else {
-
-      if (lastRow > 1 && lastColumn !== 0) {
-
         const headers = sheet.getRange(1, 1, 1, lastColumn).getValues()[0];
         const data = sheet.getRange(2, 1, lastRow - 1, lastColumn).getValues();
 
@@ -378,62 +293,42 @@ const SheetUtils = {
             row[header] = data[i][index];
           });
 
-
           rowsEvaluated++;
 
-
-          const matches = Object.keys(criteria).every(key => {
-            return String(row[key]).trim() === String(criteria[key]).trim();
+          const matches = Object.keys(normalizedCriteria).every(key => {
+            return String(row[key]).trim() === String(normalizedCriteria[key]).trim();
           });
 
           if (matches) {
-            Object.keys(updates).forEach(key => {
+            Object.keys(normalizedUpdates).forEach(key => {
               const columnIndex = headers.indexOf(key);
               if (columnIndex !== -1) {
-                const value = updates[key];
-                sheet.getRange(i + 2, columnIndex + 1).setValue(value);
+                sheet.getRange(i + 2, columnIndex + 1).setValue(normalizedUpdates[key]);
               }
             });
             success = true;
-
             exitReason = 'updated';
-
           }
         }
       }
     } catch (error) {
-
       failure = error;
       sheetLogger.error('Failed to update row by criteria', {
         sheetName,
-        criteria,
-        updates,
+        criteria: normalizedCriteria,
+        updates: normalizedUpdates,
         error: error instanceof Error ? { message: error.message, stack: error.stack } : error
-
-      sheetLogger.error('Failed to update row by criteria', {
-        error,
-        sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-        criteria,
-        updates
-
       });
       success = false;
-    } finally {
-      sheetLogger.exitFunction('updateRowByCriteria', {
-
-        sheetName,
-        success,
-        rowsEvaluated,
-        exitReason,
-        ...(failure ? { errorMessage: failure.message || String(failure) } : {})
-      });
     }
 
-
-        sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-        success
-      });
-    }
+    sheetLogger.exitFunction('updateRowByCriteria', {
+      sheetName,
+      success,
+      rowsEvaluated,
+      exitReason,
+      ...(failure ? { errorMessage: failure.message || String(failure) } : {})
+    });
 
     return success;
   },
@@ -445,7 +340,6 @@ const SheetUtils = {
    * @returns {Array<Object>} Array of row objects
    */
   getAllDataAsObjects(sheet, startRow = 2) {
-
     const sheetLogger = getSheetLogger();
     const sheetName = (sheet && typeof sheet.getName === 'function') ? sheet.getName() : 'UnknownSheet';
 
@@ -457,22 +351,15 @@ const SheetUtils = {
     let result = [];
     let failure = null;
 
-
-    sheetLogger.enterFunction('getAllDataAsObjects', {
-      sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-      startRow
-    });
-    let result = [];
-
     try {
+      if (!sheet || typeof sheet.getLastRow !== 'function') {
+        throw new Error('Invalid sheet reference provided');
+      }
+
       const lastRow = sheet.getLastRow();
       const lastColumn = sheet.getLastColumn();
 
-
       if (lastRow >= startRow && lastColumn > 0) {
-
-      if (lastRow >= startRow && lastColumn !== 0) {
-
         const headers = sheet.getRange(1, 1, 1, lastColumn).getValues()[0];
         const data = sheet.getRange(startRow, 1, lastRow - startRow + 1, lastColumn).getValues();
 
@@ -485,34 +372,20 @@ const SheetUtils = {
         });
       }
     } catch (error) {
-
       failure = error;
       sheetLogger.error('Failed to get all data as objects', {
         sheetName,
         startRow,
         error: error instanceof Error ? { message: error.message, stack: error.stack } : error
-
-      sheetLogger.error('Failed to get all data as objects', {
-        error,
-        sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-        startRow
-
       });
       result = [];
-    } finally {
-      sheetLogger.exitFunction('getAllDataAsObjects', {
-
-        sheetName,
-        rowsReturned: result.length,
-        ...(failure ? { errorMessage: failure.message || String(failure) } : {})
-      });
     }
 
-
-        sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-        rowCount: result.length
-      });
-    }
+    sheetLogger.exitFunction('getAllDataAsObjects', {
+      sheetName,
+      rowsReturned: result.length,
+      ...(failure ? { errorMessage: failure.message || String(failure) } : {})
+    });
 
     return result;
   },
@@ -523,7 +396,6 @@ const SheetUtils = {
    * @returns {boolean} Success status
    */
   clearDataKeepHeaders(sheet) {
-
     const sheetLogger = getSheetLogger();
     const sheetName = (sheet && typeof sheet.getName === 'function') ? sheet.getName() : 'UnknownSheet';
 
@@ -535,15 +407,13 @@ const SheetUtils = {
     let failure = null;
     let clearedRows = 0;
 
-    sheetLogger.enterFunction('clearDataKeepHeaders', {
-      sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined
-    });
-    let success = true;
-
     try {
+      if (!sheet || typeof sheet.getLastRow !== 'function') {
+        throw new Error('Invalid sheet reference provided');
+      }
+
       const lastRow = sheet.getLastRow();
       const lastColumn = sheet.getLastColumn();
-
 
       if (lastRow > 1 && lastColumn > 0) {
         const range = sheet.getRange(2, 1, lastRow - 1, lastColumn);
@@ -555,33 +425,16 @@ const SheetUtils = {
       sheetLogger.error('Failed to clear sheet data', {
         sheetName,
         error: error instanceof Error ? { message: error.message, stack: error.stack } : error
-
-      if (lastRow > 1 && lastColumn !== 0) {
-        const range = sheet.getRange(2, 1, lastRow - 1, lastColumn);
-        range.clear();
-      }
-    } catch (error) {
-      sheetLogger.error('Failed to clear sheet data', {
-        error,
-        sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined
-
       });
       success = false;
-    } finally {
-      sheetLogger.exitFunction('clearDataKeepHeaders', {
-
-        sheetName,
-        success,
-        clearedRows,
-        ...(failure ? { errorMessage: failure.message || String(failure) } : {})
-      });
     }
 
-
-        sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-        success
-      });
-    }
+    sheetLogger.exitFunction('clearDataKeepHeaders', {
+      sheetName,
+      success,
+      clearedRows,
+      ...(failure ? { errorMessage: failure.message || String(failure) } : {})
+    });
 
     return success;
   },
@@ -593,7 +446,6 @@ const SheetUtils = {
    * @returns {number} Column index (1-based) or -1 if not found
    */
   getColumnIndex(sheet, headerName) {
-
     const sheetLogger = getSheetLogger();
     const sheetName = (sheet && typeof sheet.getName === 'function') ? sheet.getName() : 'UnknownSheet';
 
@@ -606,6 +458,10 @@ const SheetUtils = {
     let failure = null;
 
     try {
+      if (!sheet || typeof sheet.getLastColumn !== 'function') {
+        throw new Error('Invalid sheet reference provided');
+      }
+
       const lastColumn = sheet.getLastColumn();
       if (lastColumn > 0) {
         const headers = sheet.getRange(1, 1, 1, lastColumn).getValues()[0];
@@ -618,42 +474,16 @@ const SheetUtils = {
         sheetName,
         headerName,
         error: error instanceof Error ? { message: error.message, stack: error.stack } : error
-
-    sheetLogger.enterFunction('getColumnIndex', {
-      sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-      headerName
-    });
-    let index = -1;
-    try {
-      const lastColumn = sheet.getLastColumn();
-      if (lastColumn !== 0) {
-        const headers = sheet.getRange(1, 1, 1, lastColumn).getValues()[0];
-        const headerIndex = headers.indexOf(headerName);
-        index = headerIndex === -1 ? -1 : headerIndex + 1;
-      }
-    } catch (error) {
-      sheetLogger.error('Failed to get column index', {
-        error,
-        sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-        headerName
-
       });
       index = -1;
-    } finally {
-      sheetLogger.exitFunction('getColumnIndex', {
-
-        sheetName,
-        headerName,
-        columnIndex: index,
-        ...(failure ? { errorMessage: failure.message || String(failure) } : {})
-      });
     }
 
-
-        sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-        result: index
-      });
-    }
+    sheetLogger.exitFunction('getColumnIndex', {
+      sheetName,
+      headerName,
+      columnIndex: index,
+      ...(failure ? { errorMessage: failure.message || String(failure) } : {})
+    });
 
     return index;
   },
@@ -666,7 +496,6 @@ const SheetUtils = {
    * @returns {boolean} Success status
    */
   sortByColumn(sheet, columnHeader, ascending = true) {
-
     const sheetLogger = getSheetLogger();
     const sheetName = (sheet && typeof sheet.getName === 'function') ? sheet.getName() : 'UnknownSheet';
 
@@ -680,15 +509,11 @@ const SheetUtils = {
     let failure = null;
     let rowsSorted = 0;
 
-
-    sheetLogger.enterFunction('sortByColumn', {
-      sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-      columnHeader,
-      ascending
-    });
-    let success = false;
-
     try {
+      if (!sheet || typeof sheet.getLastRow !== 'function') {
+        throw new Error('Invalid sheet reference provided');
+      }
+
       const columnIndex = this.getColumnIndex(sheet, columnHeader);
       if (columnIndex !== -1) {
         const lastRow = sheet.getLastRow();
@@ -696,53 +521,33 @@ const SheetUtils = {
 
         if (lastRow <= 2 || lastColumn === 0) {
           success = true;
-
           rowsSorted = Math.max(0, lastRow - 1);
         } else {
           const range = sheet.getRange(2, 1, lastRow - 1, lastColumn);
           rowsSorted = range.getNumRows();
-
-        } else {
-          const range = sheet.getRange(2, 1, lastRow - 1, lastColumn);
-
-          range.sort({column: columnIndex, ascending: ascending});
+          range.sort({ column: columnIndex, ascending });
           success = true;
         }
       }
     } catch (error) {
-
       failure = error;
       sheetLogger.error('Failed to sort by column', {
         sheetName,
         columnHeader,
         ascending,
         error: error instanceof Error ? { message: error.message, stack: error.stack } : error
-
-      sheetLogger.error('Failed to sort by column', {
-        error,
-        sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-        columnHeader,
-        ascending
-
       });
       success = false;
-    } finally {
-      sheetLogger.exitFunction('sortByColumn', {
-
-        sheetName,
-        columnHeader,
-        ascending,
-        success,
-        rowsSorted,
-        ...(failure ? { errorMessage: failure.message || String(failure) } : {})
-      });
     }
 
-
-        sheetName: sheet && typeof sheet.getName === 'function' ? sheet.getName() : undefined,
-        success
-      });
-    }
+    sheetLogger.exitFunction('sortByColumn', {
+      sheetName,
+      columnHeader,
+      ascending,
+      success,
+      rowsSorted,
+      ...(failure ? { errorMessage: failure.message || String(failure) } : {})
+    });
 
     return success;
   }


### PR DESCRIPTION
## Summary
- collapse duplicated logic in SheetUtils helpers so each method executes a single enter/exit logging cycle
- harden sheet operations with normalized inputs and explicit invalid-sheet guards to avoid runtime redeclarations
- streamline downstream helpers to ensure consistent error reporting and safe exits while keeping outputs intact

## Testing
- npx -y acorn@latest src/utils.gs

------
https://chatgpt.com/codex/tasks/task_e_68d2ec49e8ac83299f35af30cbc07705