### PR TITLE
Ensure initializeRequiredSheets exit logging on failure

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -189,6 +189,10 @@ class SystemCoordinator {
       
     } catch (error) {
       this.logger.error('Sheet initialization failed', { error: error.toString() });
+      this.logger.exitFunction('initializeRequiredSheets', {
+        success: false,
+        error: error.toString()
+      });
       return { success: false, error: error.toString() };
     }
   }


### PR DESCRIPTION
## Summary
- ensure SystemCoordinator.initializeRequiredSheets logs an exit event on failure paths for consistent monitoring

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d2ec4bcf908329b7d3a35a4ff97a53