### PR TITLE
Fix Apps Script deployment auth structure

### DIFF
--- a/.github/workflows/deploy-appsscript.yml
+++ b/.github/workflows/deploy-appsscript.yml
@@ -25,9 +25,9 @@ jobs:
 
     - name: Verify required secrets
       run: |
-        if [[ -z "${{ secrets.ACCESS_TOKEN }}" ]] || [[ -z "${{ secrets.REFRESH_TOKEN }}" ]] || [[ -z "${{ secrets.CLIENT_ID }}" ]] || [[ -z "${{ secrets.CLIENT_SECRET }}" ]] || [[ -z "${{ secrets.SCRIPT_ID }}" ]]; then
+        if [[ -z "${{ secrets.ACCESS_TOKEN }}" ]] || [[ -z "${{ secrets.REFRESH_TOKEN }}" ]] || [[ -z "${{ secrets.CLIENT_ID }}" ]] || [[ -z "${{ secrets.CLIENT_SECRET }}" ]] || [[ -z "${{ secrets.SCRIPT_ID }}" ]] || [[ -z "${{ secrets.ID_TOKEN }}" ]]; then
           echo "❌ Missing required secrets. Please check README-OAUTH-SETUP.md for setup instructions."
-          echo "Required secrets: ACCESS_TOKEN, REFRESH_TOKEN, CLIENT_ID, CLIENT_SECRET, SCRIPT_ID"
+          echo "Required secrets: ACCESS_TOKEN, REFRESH_TOKEN, CLIENT_ID, CLIENT_SECRET, SCRIPT_ID, ID_TOKEN"
           exit 1
         else
           echo "✅ All required secrets are configured"
@@ -36,21 +36,33 @@ jobs:
     - name: Create .clasprc.json for authentication using jq
       run: |
         echo "🔑 Creating authentication file with proper JSON escaping..."
+        EXPIRY_RAW="${{ secrets.ACCESS_TOKEN_EXPIRY }}"
+        if [[ -z "$EXPIRY_RAW" ]]; then
+          EXPIRY_RAW="0"
+        fi
         jq -n \
+          --arg access_token "${{ secrets.ACCESS_TOKEN }}" \
+          --arg refresh_token "${{ secrets.REFRESH_TOKEN }}" \
+          --arg id_token "${{ secrets.ID_TOKEN }}" \
           --arg client_id "${{ secrets.CLIENT_ID }}" \
           --arg client_secret "${{ secrets.CLIENT_SECRET }}" \
-          --arg refresh_token "${{ secrets.REFRESH_TOKEN }}" \
-          --arg access_token "${{ secrets.ACCESS_TOKEN }}" \
+          --arg scope "${{ secrets.OAUTH_SCOPE }}" \
+          --arg expiry "$EXPIRY_RAW" \
           '{
-            "tokens": {
-              "default": {
-                "client_id": $client_id,
-                "client_secret": $client_secret,
-                "type": "authorized_user",
-                "refresh_token": $refresh_token,
-                "access_token": $access_token
-              }
-            }
+            "token": {
+              "access_token": $access_token,
+              "refresh_token": $refresh_token,
+              "scope": ($scope | select(length > 0) // "https://www.googleapis.com/auth/script.projects"),
+              "token_type": "Bearer",
+              "id_token": $id_token,
+              "expiry_date": (($expiry | tonumber?) // 0)
+            },
+            "oauth2ClientSettings": {
+              "clientId": $client_id,
+              "clientSecret": $client_secret,
+              "redirectUri": "http://localhost"
+            },
+            "isLocalCreds": false
           }' > ~/.clasprc.json
         echo "✅ Authentication file created with proper JSON formatting"
 
@@ -59,7 +71,7 @@ jobs:
         echo "📋 Checking authentication setup..."
         ls -la ~/.clasprc.json
         echo "📄 File structure verification:"
-        jq 'del(.tokens.default.client_secret, .tokens.default.access_token, .tokens.default.refresh_token)' ~/.clasprc.json
+        jq 'del(.token.access_token, .token.refresh_token, .token.id_token, .oauth2ClientSettings.clientSecret)' ~/.clasprc.json
 
     - name: Create .clasp.json with Script ID
       run: |


### PR DESCRIPTION
## Summary
- ensure GitHub Actions deployment workflow validates all required Apps Script OAuth secrets, including the ID token
- generate `.clasprc.json` in the structure expected by `clasp`, including OAuth token metadata and client settings
- update authentication verification output to redact the appropriate OAuth secrets

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d34d6112608329ab040e92700a6670