### PR TITLE
Fix Apps Script deploy workflow sanitizing secrets

### DIFF
--- a/.github/workflows/deploy-appsscript.yml
+++ b/.github/workflows/deploy-appsscript.yml
@@ -33,38 +33,74 @@ jobs:
           echo "✅ All required secrets are configured"
         fi
 
-    - name: Create .clasprc.json for authentication using jq
+    - name: Create .clasprc.json for authentication
+      env:
+        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
+        ID_TOKEN: ${{ secrets.ID_TOKEN }}
+        CLIENT_ID: ${{ secrets.CLIENT_ID }}
+        CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+        OAUTH_SCOPE: ${{ secrets.OAUTH_SCOPE }}
+        ACCESS_TOKEN_EXPIRY: ${{ secrets.ACCESS_TOKEN_EXPIRY }}
       run: |
-        echo "🔑 Creating authentication file with proper JSON escaping..."
-        EXPIRY_RAW="${{ secrets.ACCESS_TOKEN_EXPIRY }}"
-        if [[ -z "$EXPIRY_RAW" ]]; then
-          EXPIRY_RAW="0"
-        fi
-        jq -n \
-          --arg access_token "${{ secrets.ACCESS_TOKEN }}" \
-          --arg refresh_token "${{ secrets.REFRESH_TOKEN }}" \
-          --arg id_token "${{ secrets.ID_TOKEN }}" \
-          --arg client_id "${{ secrets.CLIENT_ID }}" \
-          --arg client_secret "${{ secrets.CLIENT_SECRET }}" \
-          --arg scope "${{ secrets.OAUTH_SCOPE }}" \
-          --arg expiry "$EXPIRY_RAW" \
-          '{
-            "token": {
-              "access_token": $access_token,
-              "refresh_token": $refresh_token,
-              "scope": ($scope | select(length > 0) // "https://www.googleapis.com/auth/script.projects"),
-              "token_type": "Bearer",
-              "id_token": $id_token,
-              "expiry_date": (($expiry | tonumber?) // 0)
-            },
-            "oauth2ClientSettings": {
-              "clientId": $client_id,
-              "clientSecret": $client_secret,
-              "redirectUri": "http://localhost"
-            },
-            "isLocalCreds": false
-          }' > ~/.clasprc.json
-        echo "✅ Authentication file created with proper JSON formatting"
+        echo "🔑 Creating authentication file with sanitized credentials..."
+        python3 <<'PY'
+import json
+import os
+from pathlib import Path
+
+
+def sanitize_token(value: str) -> str:
+    """Remove whitespace characters that can break HTTP headers."""
+    if value is None:
+        return ""
+    # Preserve token contents while removing whitespace and line breaks
+    return "".join(value.split())
+
+
+def sanitize_field(value: str) -> str:
+    if value is None:
+        return ""
+    return value.strip()
+
+
+def parse_expiry(raw_value: str) -> int:
+    raw_value = sanitize_field(raw_value)
+    if not raw_value:
+        return 0
+    try:
+        return int(raw_value)
+    except ValueError:
+        return 0
+
+
+scope = sanitize_field(os.environ.get("OAUTH_SCOPE", ""))
+if not scope:
+    scope = "https://www.googleapis.com/auth/script.projects"
+
+config = {
+    "token": {
+        "access_token": sanitize_token(os.environ.get("ACCESS_TOKEN")),
+        "refresh_token": sanitize_token(os.environ.get("REFRESH_TOKEN")),
+        "scope": scope,
+        "token_type": "Bearer",
+        "id_token": sanitize_token(os.environ.get("ID_TOKEN")),
+        "expiry_date": parse_expiry(os.environ.get("ACCESS_TOKEN_EXPIRY")),
+    },
+    "oauth2ClientSettings": {
+        "clientId": sanitize_field(os.environ.get("CLIENT_ID")),
+        "clientSecret": sanitize_field(os.environ.get("CLIENT_SECRET")),
+        "redirectUri": "http://localhost",
+    },
+    "isLocalCreds": False,
+}
+
+Path(os.path.expanduser("~/.clasprc.json")).write_text(
+    json.dumps(config, indent=2),
+    encoding="utf-8",
+)
+PY
+        echo "✅ Authentication file created with sanitized values"
 
     - name: Verify authentication file
       run: |
@@ -74,15 +110,25 @@ jobs:
         jq 'del(.token.access_token, .token.refresh_token, .token.id_token, .oauth2ClientSettings.clientSecret)' ~/.clasprc.json
 
     - name: Create .clasp.json with Script ID
+      env:
+        SCRIPT_ID: ${{ secrets.SCRIPT_ID }}
       run: |
         echo "📝 Creating project configuration..."
-        jq -n \
-          --arg script_id "${{ secrets.SCRIPT_ID }}" \
-          '{
-            "scriptId": $script_id,
-            "rootDir": "./src",
-            "fileExtension": "gs"
-          }' > .clasp.json
+        python3 <<'PY'
+import json
+import os
+
+script_id = "".join(os.environ.get("SCRIPT_ID", "").split())
+
+config = {
+    "scriptId": script_id,
+    "rootDir": "./src",
+    "fileExtension": "gs",
+}
+
+with open(".clasp.json", "w", encoding="utf-8") as fh:
+    json.dump(config, fh, indent=2)
+PY
         echo "✅ Project configuration created"
         cat .clasp.json
 


### PR DESCRIPTION
## Summary
- sanitize OAuth secrets when generating `.clasprc.json` to remove whitespace that breaks authorization headers
- sanitize the Apps Script ID when writing `.clasp.json`

## Testing
- not run (workflow only)


------
https://chatgpt.com/codex/tasks/task_e_68d34eb13d5483298e32e19bd208339e