### PR TITLE
Add live match console UI and server handlers

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -130,6 +130,29 @@ const SYSTEM_CONFIG = {
     INSTAGRAM_POSTING: true
   },
 
+  LIVE_MATCH_CONSOLE: {
+    STATUS_OPTIONS: [
+      { id: 'kick_off', label: 'Kick-off' },
+      { id: 'half_time', label: 'Half-time' },
+      { id: 'second_half_kickoff', label: '2nd Half Kick-off' },
+      { id: 'full_time', label: 'Full-time' }
+    ],
+    CARD_TYPES: [
+      { id: 'yellow', label: 'Yellow Card' },
+      { id: 'second_yellow', label: 'Second Yellow (Red)' },
+      { id: 'red', label: 'Red Card' },
+      { id: 'sin_bin', label: 'Sin Bin' }
+    ],
+    NOTE_MARKERS: [
+      { id: 'big_chance', label: 'Big chance' },
+      { id: 'great_tackle', label: 'Great tackle' },
+      { id: 'good_play', label: 'Good play' },
+      { id: 'goal', label: 'Goal clip marker' }
+    ],
+    DEFAULT_MATCH_ID_PROPERTY: 'LIVE_MATCH_ACTIVE_ID',
+    RECENT_EVENT_LIMIT: 8
+  },
+
   // ==================== DOCUMENTATION REFERENCE ====================
   DOCUMENTATION: {
     VERSION: '6.2.0',

--- a/src/config.js.backup
+++ b/src/config.js.backup
@@ -129,6 +129,29 @@ const SYSTEM_CONFIG = {
     INSTAGRAM_POSTING: true
   },
 
+  LIVE_MATCH_CONSOLE: {
+    STATUS_OPTIONS: [
+      { id: 'kick_off', label: 'Kick-off' },
+      { id: 'half_time', label: 'Half-time' },
+      { id: 'second_half_kickoff', label: '2nd Half Kick-off' },
+      { id: 'full_time', label: 'Full-time' }
+    ],
+    CARD_TYPES: [
+      { id: 'yellow', label: 'Yellow Card' },
+      { id: 'second_yellow', label: 'Second Yellow (Red)' },
+      { id: 'red', label: 'Red Card' },
+      { id: 'sin_bin', label: 'Sin Bin' }
+    ],
+    NOTE_MARKERS: [
+      { id: 'big_chance', label: 'Big chance' },
+      { id: 'great_tackle', label: 'Great tackle' },
+      { id: 'good_play', label: 'Good play' },
+      { id: 'goal', label: 'Goal clip marker' }
+    ],
+    DEFAULT_MATCH_ID_PROPERTY: 'LIVE_MATCH_ACTIVE_ID',
+    RECENT_EVENT_LIMIT: 8
+  },
+
   // ==================== DOCUMENTATION REFERENCE ====================
   DOCUMENTATION: {
     VERSION: '6.2.0',

--- a/src/control-panel.gs
+++ b/src/control-panel.gs
@@ -1504,6 +1504,509 @@ function updateControlPanelSettings(settings) {
   }
 }
 
+// ==================== LIVE MATCH CONSOLE WEB METHODS ====================
+
+/**
+ * Retrieve state for the live match console UI
+ * @returns {Object} Live console state payload
+ */
+function getLiveMatchConsoleState() {
+  const consoleLogger = logger.scope('LiveMatchConsole');
+  consoleLogger.enterFunction('getLiveMatchConsoleState');
+
+  try {
+    const statusOptions = getConfig('LIVE_MATCH_CONSOLE.STATUS_OPTIONS', []);
+    const cardTypes = getConfig('LIVE_MATCH_CONSOLE.CARD_TYPES', []);
+    const noteMarkers = getConfig('LIVE_MATCH_CONSOLE.NOTE_MARKERS', []);
+    const recentLimit = getConfig('LIVE_MATCH_CONSOLE.RECENT_EVENT_LIMIT', 8);
+    const defaultMatchIdProperty = getConfig('LIVE_MATCH_CONSOLE.DEFAULT_MATCH_ID_PROPERTY', '');
+
+    const clubName = getConfig('SYSTEM.CLUB_NAME', 'Syston Tigers');
+    const clubShortName = getConfig('SYSTEM.CLUB_SHORT_NAME', clubName);
+
+    let defaultMatchId = '';
+    if (defaultMatchIdProperty) {
+      // @testHook(live_console_state_property_read_start)
+      defaultMatchId = PropertiesService.getScriptProperties().getProperty(defaultMatchIdProperty) || '';
+      // @testHook(live_console_state_property_read_complete)
+    }
+
+    // Player list from Player Stats sheet
+    const playerSheet = SheetUtils.getOrCreateSheet(
+      getConfig('SHEETS.TAB_NAMES.PLAYER_STATS'),
+      getConfig('SHEETS.REQUIRED_COLUMNS.PLAYER_STATS')
+    );
+
+    let players = [];
+    if (playerSheet) {
+      // @testHook(live_console_player_sheet_read)
+      const playerRows = SheetUtils.getAllDataAsObjects(playerSheet);
+      players = playerRows.map(row => (row && (row.Player || row['Player Name'])) || '').filter(Boolean);
+    }
+
+    const uniquePlayers = Array.from(new Set(players.map(value => String(value).trim()).filter(Boolean)))
+      .sort((a, b) => a.localeCompare(b));
+
+    // Live match sheet for scoreboard + recent events
+    const liveMatchSheet = SheetUtils.getOrCreateSheet(
+      getConfig('SHEETS.TAB_NAMES.LIVE_MATCH_UPDATES'),
+      getConfig('SHEETS.REQUIRED_COLUMNS.LIVE_MATCH_UPDATES')
+    );
+
+    const toScore = value => {
+      const parsed = parseInt(value, 10);
+      return Number.isFinite(parsed) ? parsed : 0;
+    };
+
+    let opponent = '';
+    let competition = '';
+    let matchId = defaultMatchId;
+    let scoreboard = { home: 0, away: 0 };
+    let recentEvents = [];
+
+    if (liveMatchSheet) {
+      // @testHook(live_console_state_sheet_read_start)
+      const liveRows = SheetUtils.getAllDataAsObjects(liveMatchSheet);
+      // @testHook(live_console_state_sheet_read_complete)
+
+      if (liveRows.length) {
+        const sortedRows = liveRows.slice().sort((a, b) => {
+          const aTime = new Date(a.Timestamp || a['Timestamp'] || 0).getTime();
+          const bTime = new Date(b.Timestamp || b['Timestamp'] || 0).getTime();
+          return aTime - bTime;
+        });
+
+        const latest = sortedRows[sortedRows.length - 1];
+        opponent = latest.Opponent || opponent;
+        competition = latest.Competition || latest.Event || latest.Status || competition;
+        matchId = (latest['Match ID'] || latest.MatchId || matchId || defaultMatchId || '').toString();
+        scoreboard = {
+          home: toScore(latest['Home Score']),
+          away: toScore(latest['Away Score'])
+        };
+
+        const startIndex = Math.max(sortedRows.length - recentLimit, 0);
+        recentEvents = sortedRows.slice(startIndex).reverse().map(row => ({
+          minute: row.Minute || row['Minute'] || '',
+          event: row.Event || row['Event'] || row.Status || '',
+          player: row.Player || '',
+          cardType: row['Card Type'] || '',
+          assist: row.Assist || '',
+          homeScore: toScore(row['Home Score']),
+          awayScore: toScore(row['Away Score']),
+          timestamp: row.Timestamp || row['Timestamp'] || '',
+          notes: row.Notes || row['Notes'] || ''
+        }));
+      }
+    }
+
+    const info = {
+      clubName: clubName,
+      clubShortName: clubShortName,
+      opponent: opponent,
+      competition: competition,
+      matchId: matchId || defaultMatchId || '',
+      defaultMatchId: defaultMatchId || '',
+      homeName: clubShortName
+    };
+
+    const payload = {
+      success: true,
+      info: info,
+      players: uniquePlayers,
+      statusOptions: statusOptions,
+      cardTypes: cardTypes,
+      noteMarkers: noteMarkers,
+      scoreboard: scoreboard,
+      recentEvents: recentEvents
+    };
+
+    consoleLogger.exitFunction('getLiveMatchConsoleState', {
+      success: true,
+      players: uniquePlayers.length,
+      events: recentEvents.length
+    });
+
+    return payload;
+
+  } catch (error) {
+    consoleLogger.error('Failed to load live match console state', { error: error.toString() });
+    consoleLogger.exitFunction('getLiveMatchConsoleState', { success: false });
+    return { success: false, error: error.toString() };
+  }
+}
+
+/**
+ * Record a goal event via the live match console
+ * @param {Object} payload - Goal payload
+ * @returns {Object} Result
+ */
+function recordLiveMatchGoal(payload) {
+  const consoleLogger = logger.scope('LiveMatchConsole');
+  consoleLogger.enterFunction('recordLiveMatchGoal', { requestId: payload && payload.requestId });
+
+  try {
+    const requestId = sanitizeLiveConsoleField(payload && payload.requestId);
+    const guard = prepareLiveConsoleGuard(requestId, 'goal');
+
+    const minute = sanitizeLiveConsoleField(payload && payload.minute);
+    const player = sanitizeLiveConsoleField(payload && payload.player);
+    const assist = sanitizeLiveConsoleField(payload && payload.assist);
+    const note = sanitizeLiveConsoleField(payload && payload.note);
+    const matchId = sanitizeLiveConsoleField(payload && payload.matchId) || null;
+
+    if (!minute || !player) {
+      throw new Error('Minute and scorer are required');
+    }
+
+    const manager = new EnhancedEventsManager();
+    // @testHook(live_console_goal_request)
+    const result = manager.processGoalEvent(minute, player, assist, matchId);
+
+    if (result && result.success) {
+      if (note) {
+        writeLiveConsoleNote(matchId, minute, 'Goal note', player, note);
+      }
+      commitLiveConsoleGuard(guard);
+    }
+
+    consoleLogger.exitFunction('recordLiveMatchGoal', { success: !!(result && result.success) });
+    return result;
+
+  } catch (error) {
+    if (error && error.code === 'DUPLICATE_LIVE_REQUEST') {
+      consoleLogger.warn('Duplicate goal request ignored', { requestId: payload && payload.requestId });
+      consoleLogger.exitFunction('recordLiveMatchGoal', { success: true, duplicate: true });
+      return { success: true, duplicate: true, message: 'Duplicate request ignored' };
+    }
+
+    consoleLogger.error('Live match goal submission failed', { error: error.toString() });
+    consoleLogger.exitFunction('recordLiveMatchGoal', { success: false });
+    return { success: false, error: error.toString() };
+  }
+}
+
+/**
+ * Record a card event via the live console
+ * @param {Object} payload - Card payload
+ * @returns {Object} Result
+ */
+function recordLiveMatchCard(payload) {
+  const consoleLogger = logger.scope('LiveMatchConsole');
+  consoleLogger.enterFunction('recordLiveMatchCard', { requestId: payload && payload.requestId });
+
+  try {
+    const requestId = sanitizeLiveConsoleField(payload && payload.requestId);
+    const guard = prepareLiveConsoleGuard(requestId, 'card');
+
+    const minute = sanitizeLiveConsoleField(payload && payload.minute);
+    const player = sanitizeLiveConsoleField(payload && payload.player);
+    const cardTypeId = sanitizeLiveConsoleField(payload && payload.cardType);
+    const note = sanitizeLiveConsoleField(payload && payload.note);
+    const matchId = sanitizeLiveConsoleField(payload && payload.matchId) || null;
+
+    if (!minute || !player || !cardTypeId) {
+      throw new Error('Minute, player, and card type are required');
+    }
+
+    const normalisedCardType = mapLiveConsoleCardType(cardTypeId);
+    const manager = new EnhancedEventsManager();
+    // @testHook(live_console_card_request)
+    const result = manager.processCardEvent(minute, player, normalisedCardType, matchId);
+
+    if (result && result.success) {
+      if (note) {
+        writeLiveConsoleNote(matchId, minute, 'Card note', player, note);
+      }
+      commitLiveConsoleGuard(guard);
+    }
+
+    consoleLogger.exitFunction('recordLiveMatchCard', { success: !!(result && result.success) });
+    return result;
+
+  } catch (error) {
+    if (error && error.code === 'DUPLICATE_LIVE_REQUEST') {
+      consoleLogger.warn('Duplicate card request ignored', { requestId: payload && payload.requestId });
+      consoleLogger.exitFunction('recordLiveMatchCard', { success: true, duplicate: true });
+      return { success: true, duplicate: true, message: 'Duplicate request ignored' };
+    }
+
+    consoleLogger.error('Live match card submission failed', { error: error.toString() });
+    consoleLogger.exitFunction('recordLiveMatchCard', { success: false });
+    return { success: false, error: error.toString() };
+  }
+}
+
+/**
+ * Record a substitution event via the live console
+ * @param {Object} payload - Substitution payload
+ * @returns {Object} Result
+ */
+function recordLiveMatchSubstitution(payload) {
+  const consoleLogger = logger.scope('LiveMatchConsole');
+  consoleLogger.enterFunction('recordLiveMatchSubstitution', { requestId: payload && payload.requestId });
+
+  try {
+    const requestId = sanitizeLiveConsoleField(payload && payload.requestId);
+    const guard = prepareLiveConsoleGuard(requestId, 'substitution');
+
+    const minute = sanitizeLiveConsoleField(payload && payload.minute);
+    const playerOff = sanitizeLiveConsoleField(payload && payload.playerOff);
+    const playerOn = sanitizeLiveConsoleField(payload && payload.playerOn);
+    const note = sanitizeLiveConsoleField(payload && payload.note);
+    const matchId = sanitizeLiveConsoleField(payload && payload.matchId) || null;
+
+    if (!minute || !playerOff || !playerOn) {
+      throw new Error('Minute, player off, and player on are required');
+    }
+
+    const manager = new EnhancedEventsManager();
+    // @testHook(live_console_sub_request)
+    const result = manager.processSubstitution(minute, playerOff, playerOn, matchId);
+
+    if (result && result.success) {
+      if (note) {
+        writeLiveConsoleNote(matchId, minute, 'Substitution note', `${playerOff} ➜ ${playerOn}`, note);
+      }
+      commitLiveConsoleGuard(guard);
+    }
+
+    consoleLogger.exitFunction('recordLiveMatchSubstitution', { success: !!(result && result.success) });
+    return result;
+
+  } catch (error) {
+    if (error && error.code === 'DUPLICATE_LIVE_REQUEST') {
+      consoleLogger.warn('Duplicate substitution request ignored', { requestId: payload && payload.requestId });
+      consoleLogger.exitFunction('recordLiveMatchSubstitution', { success: true, duplicate: true });
+      return { success: true, duplicate: true, message: 'Duplicate request ignored' };
+    }
+
+    consoleLogger.error('Live match substitution failed', { error: error.toString() });
+    consoleLogger.exitFunction('recordLiveMatchSubstitution', { success: false });
+    return { success: false, error: error.toString() };
+  }
+}
+
+/**
+ * Record a match status event via the live console
+ * @param {Object} payload - Status payload
+ * @returns {Object} Result
+ */
+function recordLiveMatchStatus(payload) {
+  const consoleLogger = logger.scope('LiveMatchConsole');
+  consoleLogger.enterFunction('recordLiveMatchStatus', { requestId: payload && payload.requestId, statusId: payload && payload.statusId });
+
+  try {
+    const requestId = sanitizeLiveConsoleField(payload && payload.requestId);
+    const guard = prepareLiveConsoleGuard(requestId, 'status');
+
+    const statusId = sanitizeLiveConsoleField(payload && payload.statusId).toLowerCase();
+    const matchId = sanitizeLiveConsoleField(payload && payload.matchId) || null;
+
+    if (!statusId) {
+      throw new Error('Status identifier is required');
+    }
+
+    const manager = new EnhancedEventsManager();
+    const handlers = {
+      'kick_off': () => manager.processKickOff(matchId),
+      'half_time': () => manager.processHalfTime(matchId),
+      'second_half_kickoff': () => manager.processSecondHalfKickOff(matchId),
+      'full_time': () => manager.processFullTime(matchId)
+    };
+
+    const handler = handlers[statusId];
+    if (!handler) {
+      throw new Error('Unknown status: ' + statusId);
+    }
+
+    // @testHook(live_console_status_request)
+    const result = handler();
+    if (result && result.success) {
+      commitLiveConsoleGuard(guard);
+    }
+
+    consoleLogger.exitFunction('recordLiveMatchStatus', { success: !!(result && result.success) });
+    return result;
+
+  } catch (error) {
+    if (error && error.code === 'DUPLICATE_LIVE_REQUEST') {
+      consoleLogger.warn('Duplicate status request ignored', { requestId: payload && payload.requestId });
+      consoleLogger.exitFunction('recordLiveMatchStatus', { success: true, duplicate: true });
+      return { success: true, duplicate: true, message: 'Duplicate request ignored' };
+    }
+
+    consoleLogger.error('Live match status submission failed', { error: error.toString() });
+    consoleLogger.exitFunction('recordLiveMatchStatus', { success: false });
+    return { success: false, error: error.toString() };
+  }
+}
+
+/**
+ * Record a video editor note via the live console
+ * @param {Object} payload - Note payload
+ * @returns {Object} Result
+ */
+function recordLiveMatchNote(payload) {
+  const consoleLogger = logger.scope('LiveMatchConsole');
+  consoleLogger.enterFunction('recordLiveMatchNote', { requestId: payload && payload.requestId });
+
+  try {
+    const requestId = sanitizeLiveConsoleField(payload && payload.requestId);
+    const guard = prepareLiveConsoleGuard(requestId, 'note');
+
+    const minute = sanitizeLiveConsoleField(payload && payload.minute);
+    const noteType = sanitizeLiveConsoleField(payload && payload.noteType) || 'Video note';
+    const player = sanitizeLiveConsoleField(payload && payload.player);
+    const details = sanitizeLiveConsoleField(payload && payload.details);
+    const matchId = sanitizeLiveConsoleField(payload && payload.matchId) || null;
+
+    writeLiveConsoleNote(matchId, minute, noteType, player, details);
+    commitLiveConsoleGuard(guard);
+
+    consoleLogger.exitFunction('recordLiveMatchNote', { success: true });
+    return { success: true };
+
+  } catch (error) {
+    if (error && error.code === 'DUPLICATE_LIVE_REQUEST') {
+      consoleLogger.warn('Duplicate note request ignored', { requestId: payload && payload.requestId });
+      consoleLogger.exitFunction('recordLiveMatchNote', { success: true, duplicate: true });
+      return { success: true, duplicate: true, message: 'Duplicate request ignored' };
+    }
+
+    consoleLogger.error('Live match note submission failed', { error: error.toString() });
+    consoleLogger.exitFunction('recordLiveMatchNote', { success: false });
+    return { success: false, error: error.toString() };
+  }
+}
+
+// ==================== LIVE MATCH CONSOLE HELPERS ====================
+
+/**
+ * Guard repeated submissions using request identifiers
+ * @param {string} requestId - Unique identifier
+ * @param {string} action - Action name
+ * @returns {Object} Guard context
+ */
+function prepareLiveConsoleGuard(requestId, action) {
+  const guardLogger = logger.scope('LiveMatchGuard');
+  guardLogger.enterFunction('prepareLiveConsoleGuard', { requestId: requestId, action: action });
+
+  if (!requestId) {
+    guardLogger.exitFunction('prepareLiveConsoleGuard', { success: false, reason: 'missing_request_id' });
+    throw new Error('Missing request identifier');
+  }
+
+  const cache = CacheService.getScriptCache();
+  const cacheKey = `live_console_${requestId}`;
+  const existing = cache.get(cacheKey);
+
+  if (existing) {
+    const duplicateError = new Error('Duplicate live match console request');
+    duplicateError.code = 'DUPLICATE_LIVE_REQUEST';
+    guardLogger.exitFunction('prepareLiveConsoleGuard', { success: false, reason: 'duplicate' });
+    throw duplicateError;
+  }
+
+  guardLogger.exitFunction('prepareLiveConsoleGuard', { success: true });
+  return { cache: cache, cacheKey: cacheKey };
+}
+
+/**
+ * Persist guard state after successful execution
+ * @param {Object} guard - Guard context
+ */
+function commitLiveConsoleGuard(guard) {
+  if (!guard || !guard.cache || !guard.cacheKey) {
+    return;
+  }
+  guard.cache.put(guard.cacheKey, 'processed', 21600); // 6 hours
+}
+
+/**
+ * Convert console payload fields to trimmed strings
+ * @param {*} value - Value to sanitize
+ * @returns {string} Sanitized text
+ */
+function sanitizeLiveConsoleField(value) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+/**
+ * Map select identifiers to card types understood by the event processor
+ * @param {string} identifier - Identifier from UI
+ * @returns {string} Normalised card type string
+ */
+function mapLiveConsoleCardType(identifier) {
+  const value = sanitizeLiveConsoleField(identifier).toLowerCase();
+  switch (value) {
+    case 'yellow':
+      return 'yellow';
+    case 'second_yellow':
+    case 'second yellow':
+      return 'second yellow (red)';
+    case 'red':
+      return 'red';
+    case 'sin_bin':
+    case 'sin bin':
+      return 'sin_bin';
+    default:
+      return identifier;
+  }
+}
+
+/**
+ * Append a note into the Live Match Updates sheet for video editors
+ * @param {string} matchId - Match identifier
+ * @param {string} minute - Minute marker
+ * @param {string} eventName - Note event name
+ * @param {string} player - Player reference
+ * @param {string} details - Note body
+ */
+function writeLiveConsoleNote(matchId, minute, eventName, player, details) {
+  const noteLogger = logger.scope('LiveMatchConsoleNote');
+  noteLogger.enterFunction('writeLiveConsoleNote', { matchId: matchId, eventName: eventName });
+
+  try {
+    const liveMatchSheet = SheetUtils.getOrCreateSheet(
+      getConfig('SHEETS.TAB_NAMES.LIVE_MATCH_UPDATES'),
+      getConfig('SHEETS.REQUIRED_COLUMNS.LIVE_MATCH_UPDATES')
+    );
+
+    if (!liveMatchSheet) {
+      throw new Error('Live Match Updates sheet not available');
+    }
+
+    const row = {
+      'Timestamp': DateUtils.formatISO(DateUtils.now()),
+      'Minute': minute || '',
+      'Event': eventName || 'Note',
+      'Player': player || '',
+      'Opponent': '',
+      'Home Score': '',
+      'Away Score': '',
+      'Card Type': '',
+      'Assist': '',
+      'Notes': details || '',
+      'Send': 'FALSE',
+      'Status': eventName || 'NOTE',
+      'Match ID': matchId || ''
+    };
+
+    // @testHook(live_console_note_sheet_write)
+    SheetUtils.addRowFromObject(liveMatchSheet, row);
+
+    noteLogger.exitFunction('writeLiveConsoleNote', { success: true });
+
+  } catch (error) {
+    noteLogger.error('Failed to store live console note', { error: error.toString() });
+    noteLogger.exitFunction('writeLiveConsoleNote', { success: false });
+  }
+}
+
 /** Run actions requested by the web UI */
 function actionRunRunner(name) {
   try {

--- a/src/controlPanel.html
+++ b/src/controlPanel.html
@@ -40,14 +40,51 @@
     .privacy-block { margin-top:12px; }
     .toggle-stack { display:flex; flex-direction:column; gap:10px; width:100%; }
     .toggle-item small { color:#6b7280; }
+    .tabs { display:flex; flex-wrap:wrap; align-items:center; gap:10px; margin:20px 0; }
+    .tab-btn { background:#111; color:#ddd; border:1px solid #222; border-radius:999px; padding:8px 16px; cursor:pointer; font-size:13px; letter-spacing:.04em; text-transform:uppercase; }
+    .tab-btn.active { background:var(--accent); color:#000; border-color:#e6be00; font-weight:700; }
+    .tab-hint { color:var(--muted); font-size:12px; margin-left:auto; }
+    .view { display:none; }
+    .view.active { display:block; }
+    .hidden { display:none !important; }
+    .flash { padding:12px 16px; border-radius:12px; border:1px solid transparent; margin-bottom:16px; font-size:13px; }
+    .flash.success { background:rgba(41,167,69,.12); border-color:#215c33; color:#b6ffca; }
+    .flash.error { background:rgba(220,53,69,.12); border-color:#5c2121; color:#ffc2c7; }
+    .flash.info { background:rgba(224,168,0,.12); border-color:#5c4a21; color:#ffe8a6; }
+    .live-grid { display:grid; grid-template-columns: repeat(auto-fit,minmax(320px,1fr)); gap:16px; }
+    .form-grid { display:grid; gap:12px; }
+    .form-grid label { font-size:11px; color:var(--muted); letter-spacing:.08em; text-transform:uppercase; }
+    .form-grid input,
+    .form-grid select,
+    .form-grid textarea { background:#0f0f0f; border:1px solid #222; border-radius:10px; padding:10px 12px; color:#fff; font-size:14px; font-family:inherit; }
+    .form-grid textarea { min-height:80px; resize:vertical; }
+    .scoreboard { display:flex; align-items:center; justify-content:space-between; gap:18px; padding:10px 0; }
+    .scoreboard .team { flex:1; text-align:center; }
+    .scoreboard .team-name { font-size:16px; color:#f6f6f6; font-weight:600; margin-bottom:4px; }
+    .scoreboard .team-score { font-size:48px; font-weight:700; }
+    .scoreboard .vs { font-size:14px; color:var(--muted); text-transform:uppercase; letter-spacing:.2em; }
+    .status-grid { display:flex; flex-wrap:wrap; gap:10px; margin-top:12px; }
+    .status-grid button { flex:1 1 150px; justify-content:center; }
+    .event-list { list-style:none; margin:0; padding:0; display:grid; gap:10px; }
+    .event-item { background:#101010; border-radius:12px; border:1px solid #222; padding:12px; }
+    .event-item .time { font-size:11px; color:var(--muted); letter-spacing:.08em; text-transform:uppercase; margin-bottom:4px; }
+    .event-item .body { color:#fff; font-size:14px; line-height:1.45; }
+    .muted span.score { color:#f6f6f6; font-weight:600; }
   </style>
 </head>
 <body>
   <div class="wrap">
-    <h1>⚙️ Syston Tigers – Control Panel</h1>
+    <h1>⚙️ Syston Tigers – Operations Console</h1>
 
-    <div class="grid">
-      <div class="card">
+    <div class="tabs">
+      <button class="tab-btn active" data-view="control">Control panel</button>
+      <button class="tab-btn" data-view="live">Live match console</button>
+      <div class="tab-hint">Live tools stay Make.com friendly & Bible compliant</div>
+    </div>
+
+    <section id="controlView" class="view active">
+      <div class="grid">
+        <div class="card">
         <h2>System status</h2>
         <div id="statusPills" class="btn-row" style="margin-bottom:10px;"></div>
         <div class="kv" id="sysInfo"></div>
@@ -98,13 +135,111 @@
           <small class="code">results_1_league … results_5_league</small>, <small class="code">match_postponed</small>).<br>
           • Script Properties must set <small class="code">SPREADSHEET_ID</small> and <small class="code">MAKE_WEBHOOK_URL</small>.
         </div>
+        </div>
       </div>
-    </div>
+    </section>
+
+    <section id="liveView" class="view">
+      <div id="liveFlash" class="flash hidden"></div>
+      <div class="live-grid">
+        <div class="card">
+          <h2>Scoreboard</h2>
+          <div class="scoreboard">
+            <div class="team">
+              <div class="team-name" id="homeTeamName">Syston Tigers</div>
+              <div class="team-score" id="homeScore">0</div>
+            </div>
+            <div class="vs">vs</div>
+            <div class="team">
+              <div class="team-name" id="awayTeamName">Opponent</div>
+              <div class="team-score" id="awayScore">0</div>
+            </div>
+          </div>
+          <div class="muted" id="matchMeta">Match details pending</div>
+          <div class="row" style="margin-top:12px;">
+            <div class="muted">Refresh latest live data snapshot</div>
+            <button id="liveRefresh" class="btn" type="button" onclick="loadLiveConsoleState()">Refresh</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Match status</h2>
+          <div class="muted">Kick-off, half-time, second-half, and full-time posts</div>
+          <div id="statusButtons" class="status-grid"></div>
+        </div>
+
+        <div class="card">
+          <h2>Goal</h2>
+          <form id="goalForm" class="form-grid" onsubmit="submitGoal(event)">
+            <label for="goalMinute">Minute</label>
+            <input id="goalMinute" type="number" min="0" max="130" placeholder="e.g. 42">
+            <label for="goalPlayer">Scorer</label>
+            <select id="goalPlayer"></select>
+            <label for="goalAssist">Assist (optional)</label>
+            <select id="goalAssist"></select>
+            <label for="goalNote">Internal note (optional)</label>
+            <textarea id="goalNote" placeholder="Brace detection handled automatically"></textarea>
+            <button id="goalSubmit" class="btn primary" type="submit" data-live-submit>Record goal</button>
+          </form>
+        </div>
+
+        <div class="card">
+          <h2>Card</h2>
+          <form id="cardForm" class="form-grid" onsubmit="submitCard(event)">
+            <label for="cardMinute">Minute</label>
+            <input id="cardMinute" type="number" min="0" max="130" placeholder="e.g. 67">
+            <label for="cardPlayer">Player</label>
+            <select id="cardPlayer"></select>
+            <label for="cardType">Card type</label>
+            <select id="cardType"></select>
+            <label for="cardNote">Internal note (optional)</label>
+            <textarea id="cardNote" placeholder="E.g. dissent, tactical"></textarea>
+            <button id="cardSubmit" class="btn primary" type="submit" data-live-submit>Record card</button>
+          </form>
+        </div>
+
+        <div class="card">
+          <h2>Substitution</h2>
+          <form id="subForm" class="form-grid" onsubmit="submitSub(event)">
+            <label for="subMinute">Minute</label>
+            <input id="subMinute" type="number" min="0" max="130" placeholder="e.g. 74">
+            <label for="playerOff">Player off</label>
+            <select id="playerOff"></select>
+            <label for="playerOn">Player on</label>
+            <select id="playerOn"></select>
+            <label for="subNote">Internal note (optional)</label>
+            <textarea id="subNote" placeholder="E.g. tactical, injury"></textarea>
+            <button id="subSubmit" class="btn primary" type="submit" data-live-submit>Record substitution</button>
+          </form>
+        </div>
+
+        <div class="card">
+          <h2>Video notes</h2>
+          <form id="noteForm" class="form-grid" onsubmit="submitNote(event)">
+            <label for="noteMinute">Minute</label>
+            <input id="noteMinute" type="number" min="0" max="130" placeholder="e.g. 51">
+            <label for="noteType">Marker</label>
+            <select id="noteType"></select>
+            <label for="notePlayer">Player</label>
+            <select id="notePlayer"></select>
+            <label for="noteDetails">Details</label>
+            <textarea id="noteDetails" placeholder="E.g. &quot;Huge save&quot; or &quot;Great build-up&quot;"></textarea>
+            <button id="noteSubmit" class="btn primary" type="submit" data-live-submit>Save note</button>
+          </form>
+        </div>
+
+        <div class="card" style="grid-column:1 / -1;">
+          <h2>Recent events</h2>
+          <ul id="recentEvents" class="event-list"></ul>
+        </div>
+      </div>
+    </section>
   </div>
 
   <script>
     const el = s => document.querySelector(s);
     const pills = (arr) => arr.map(x => `<span class="pill ${x.cls}">${x.text}</span>`).join('');
+    const liveState = { loaded: false, data: null, readyMessageShown: false };
 
     function loadState() {
       google.script.run.withSuccessHandler(state => {
@@ -219,7 +354,465 @@
       }).actionRunRunner(name);
     }
 
-    document.addEventListener('DOMContentLoaded', loadState);
+    function initTabs() {
+      const buttons = document.querySelectorAll('.tab-btn[data-view]');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          const view = btn.dataset.view;
+          showView(view);
+        });
+      });
+    }
+
+    function showView(viewName) {
+      const targetId = viewName === 'live' ? 'liveView' : 'controlView';
+      document.querySelectorAll('.view').forEach(section => {
+        section.classList.toggle('active', section.id === targetId);
+      });
+      document.querySelectorAll('.tab-btn[data-view]').forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.view === viewName);
+      });
+
+      if (viewName === 'live' && !liveState.loaded) {
+        loadLiveConsoleState();
+      }
+    }
+
+    function setLiveLoading(isLoading) {
+      const refreshBtn = el('#liveRefresh');
+      if (refreshBtn) {
+        if (isLoading) {
+          refreshBtn.dataset.originalLabel = refreshBtn.textContent;
+          refreshBtn.textContent = 'Loading…';
+        } else {
+          refreshBtn.textContent = refreshBtn.dataset.originalLabel || 'Refresh';
+        }
+        refreshBtn.disabled = isLoading;
+      }
+      document.querySelectorAll('[data-live-submit]').forEach(button => {
+        if (isLoading) {
+          button.dataset.originalLabel = button.textContent;
+          button.textContent = 'Please wait…';
+        } else if (button.dataset.originalLabel) {
+          button.textContent = button.dataset.originalLabel;
+        }
+        button.disabled = isLoading;
+      });
+    }
+
+    function loadLiveConsoleState(showSpinner = true) {
+      if (showSpinner) {
+        setLiveLoading(true);
+      }
+      google.script.run
+        .withSuccessHandler(state => {
+          liveState.loaded = true;
+          liveState.data = state;
+          renderLiveConsole(state);
+          setLiveLoading(false);
+        })
+        .withFailureHandler(err => {
+          setLiveLoading(false);
+          showLiveFlash('error', 'Failed to load live data: ' + (err && err.message ? err.message : err));
+        })
+        .getLiveMatchConsoleState();
+    }
+
+    function renderLiveConsole(state) {
+      if (!state || state.success === false) {
+        showLiveFlash('error', state && state.error ? state.error : 'Unable to load live match data');
+        return;
+      }
+
+      const info = state.info || {};
+      const scoreboard = state.scoreboard || { home: 0, away: 0 };
+
+      if (el('#homeTeamName')) {
+        el('#homeTeamName').textContent = info.homeName || info.clubShortName || info.clubName || 'Syston Tigers';
+      }
+      if (el('#awayTeamName')) {
+        el('#awayTeamName').textContent = info.opponent || 'Opponent';
+      }
+      if (el('#homeScore')) {
+        el('#homeScore').textContent = typeof scoreboard.home === 'number' ? scoreboard.home : (scoreboard.home || 0);
+      }
+      if (el('#awayScore')) {
+        el('#awayScore').textContent = typeof scoreboard.away === 'number' ? scoreboard.away : (scoreboard.away || 0);
+      }
+      if (el('#matchMeta')) {
+        const matchBits = [];
+        if (info.competition) matchBits.push(info.competition);
+        if (info.matchId) matchBits.push('ID: ' + info.matchId);
+        if (state.recentEvents && state.recentEvents.length && state.recentEvents[0].timestamp) {
+          matchBits.push('Updated ' + formatEventTime(state.recentEvents[0].timestamp));
+        }
+        el('#matchMeta').textContent = matchBits.length ? matchBits.join(' • ') : 'Match details pending';
+      }
+
+      renderStatusButtons(state.statusOptions || []);
+      populatePlayerSelects(state.players || []);
+      populateCardTypeSelect(state.cardTypes || []);
+      populateNoteTypeSelect(state.noteMarkers || []);
+      renderRecentEvents(state.recentEvents || []);
+
+      if (!liveState.readyMessageShown) {
+        showLiveFlash('info', 'Live match console ready');
+        liveState.readyMessageShown = true;
+      }
+    }
+
+    function renderStatusButtons(options) {
+      const container = el('#statusButtons');
+      if (!container) {
+        return;
+      }
+      if (!options.length) {
+        container.innerHTML = '<div class="muted">No status actions configured.</div>';
+        return;
+      }
+      container.innerHTML = options.map(opt => {
+        return `<button type="button" class="btn" data-status-btn="${opt.id}" onclick="submitStatus('${opt.id}')">${opt.label}</button>`;
+      }).join('');
+    }
+
+    function populatePlayerSelects(players) {
+      const uniques = Array.from(new Set(players.filter(Boolean).map(p => String(p).trim()).filter(Boolean))).sort((a, b) => a.localeCompare(b));
+      const goalOptions = [{ value: 'Goal', label: 'Opposition Goal' }].concat(uniques.map(name => ({ value: name, label: name })));
+      setSelectOptions('#goalPlayer', goalOptions, 'Select scorer');
+      const assistOptions = [{ value: '', label: 'No assist' }].concat(uniques.map(name => ({ value: name, label: name })));
+      setSelectOptions('#goalAssist', assistOptions, 'No assist');
+
+      const cardExtras = [{ value: 'Opposition', label: 'Opposition' }];
+      const cardOptions = cardExtras.concat(uniques.map(name => ({ value: name, label: name })));
+      setSelectOptions('#cardPlayer', cardOptions, 'Select player');
+
+      setSelectOptions('#playerOff', uniques.map(name => ({ value: name, label: name })), 'Select player off');
+      setSelectOptions('#playerOn', uniques.map(name => ({ value: name, label: name })), 'Select player on');
+
+      const notePlayers = [{ value: 'Team', label: 'Team' }, { value: 'Opposition', label: 'Opposition' }].concat(uniques.map(name => ({ value: name, label: name })));
+      setSelectOptions('#notePlayer', notePlayers, 'Select player');
+    }
+
+    function populateCardTypeSelect(cardTypes) {
+      const options = (cardTypes || []).map(type => ({ value: type.id || type.value || type, label: type.label || type.name || type }));
+      setSelectOptions('#cardType', options, 'Select card type');
+    }
+
+    function populateNoteTypeSelect(noteTypes) {
+      const options = (noteTypes || []).map(type => ({ value: type.id || type.value || type, label: type.label || type.name || type }));
+      setSelectOptions('#noteType', options, 'Select marker');
+    }
+
+    function setSelectOptions(selector, options, placeholder) {
+      const select = el(selector);
+      if (!select) {
+        return;
+      }
+      const merged = [{ value: '', label: placeholder || 'Select option' }].concat(options || []);
+      select.innerHTML = merged.map(opt => `<option value="${opt.value ?? ''}">${opt.label ?? opt.value ?? ''}</option>`).join('');
+    }
+
+    function renderRecentEvents(events) {
+      const list = el('#recentEvents');
+      if (!list) {
+        return;
+      }
+      if (!events.length) {
+        list.innerHTML = '<li class="muted">No live events captured yet.</li>';
+        return;
+      }
+      list.innerHTML = events.map(event => {
+        const minute = event.minute ? `${event.minute}'` : '';
+        const player = event.player ? ` · ${event.player}` : '';
+        const card = event.cardType ? ` · ${event.cardType}` : '';
+        const notes = event.notes ? `<div class="muted">${event.notes}</div>` : '';
+        const score = typeof event.homeScore === 'number' && typeof event.awayScore === 'number'
+          ? `<span class="score">${event.homeScore} - ${event.awayScore}</span>`
+          : '';
+        return `
+          <li class="event-item">
+            <div class="time">${formatEventTime(event.timestamp)} ${minute}</div>
+            <div class="body"><strong>${event.event || 'Event'}</strong>${player}${card}${score ? ' · ' + score : ''}</div>
+            ${notes}
+          </li>
+        `;
+      }).join('');
+    }
+
+    function formatEventTime(timestamp) {
+      if (!timestamp) {
+        return '';
+      }
+      try {
+        const date = new Date(timestamp);
+        if (!isNaN(date.getTime())) {
+          return date.toLocaleString('en-GB', { day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit', hour12: false });
+        }
+      } catch (error) {
+        // Ignore parse errors and fall through
+      }
+      return timestamp;
+    }
+
+    function showLiveFlash(type, message) {
+      const box = el('#liveFlash');
+      if (!box) {
+        return;
+      }
+      box.classList.remove('hidden', 'success', 'error', 'info');
+      box.classList.add(type || 'info');
+      box.textContent = message;
+      if (box.dataset.timeoutId) {
+        clearTimeout(Number(box.dataset.timeoutId));
+      }
+      const timeout = setTimeout(() => {
+        box.classList.add('hidden');
+      }, 5000);
+      box.dataset.timeoutId = String(timeout);
+    }
+
+    function generateRequestId() {
+      return `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    }
+
+    function getActiveMatchId() {
+      if (liveState && liveState.data && liveState.data.info) {
+        return liveState.data.info.matchId || liveState.data.info.defaultMatchId || '';
+      }
+      return '';
+    }
+
+    function submitGoal(event) {
+      event.preventDefault();
+      const minute = (el('#goalMinute')?.value || '').trim();
+      const player = (el('#goalPlayer')?.value || '').trim();
+      const assist = el('#goalAssist')?.value || '';
+      const note = (el('#goalNote')?.value || '').trim();
+
+      if (!minute || !player) {
+        showLiveFlash('error', 'Minute and scorer are required');
+        return;
+      }
+
+      const button = el('#goalSubmit');
+      if (button) {
+        button.disabled = true;
+        button.dataset.originalLabel = button.textContent;
+        button.textContent = 'Recording…';
+      }
+
+      const payload = {
+        requestId: generateRequestId(),
+        minute,
+        player,
+        assist,
+        note,
+        matchId: getActiveMatchId()
+      };
+
+      google.script.run
+        .withSuccessHandler(result => {
+          handleLiveResult(result, 'Goal recorded successfully');
+          if (result && result.success) {
+            event.target.reset();
+          }
+          resetButton(button);
+        })
+        .withFailureHandler(err => {
+          showLiveFlash('error', 'Failed to record goal: ' + (err && err.message ? err.message : err));
+          resetButton(button);
+        })
+        .recordLiveMatchGoal(payload);
+    }
+
+    function submitCard(event) {
+      event.preventDefault();
+      const minute = (el('#cardMinute')?.value || '').trim();
+      const player = (el('#cardPlayer')?.value || '').trim();
+      const cardType = (el('#cardType')?.value || '').trim();
+      const note = (el('#cardNote')?.value || '').trim();
+
+      if (!minute || !player || !cardType) {
+        showLiveFlash('error', 'Minute, player, and card type are required');
+        return;
+      }
+
+      const button = el('#cardSubmit');
+      if (button) {
+        button.disabled = true;
+        button.dataset.originalLabel = button.textContent;
+        button.textContent = 'Recording…';
+      }
+
+      const payload = {
+        requestId: generateRequestId(),
+        minute,
+        player,
+        cardType,
+        note,
+        matchId: getActiveMatchId()
+      };
+
+      google.script.run
+        .withSuccessHandler(result => {
+          handleLiveResult(result, 'Card recorded successfully');
+          if (result && result.success) {
+            event.target.reset();
+          }
+          resetButton(button);
+        })
+        .withFailureHandler(err => {
+          showLiveFlash('error', 'Failed to record card: ' + (err && err.message ? err.message : err));
+          resetButton(button);
+        })
+        .recordLiveMatchCard(payload);
+    }
+
+    function submitSub(event) {
+      event.preventDefault();
+      const minute = (el('#subMinute')?.value || '').trim();
+      const playerOff = (el('#playerOff')?.value || '').trim();
+      const playerOn = (el('#playerOn')?.value || '').trim();
+      const note = (el('#subNote')?.value || '').trim();
+
+      if (!minute || !playerOff || !playerOn) {
+        showLiveFlash('error', 'Minute, player off, and player on are required');
+        return;
+      }
+
+      const button = el('#subSubmit');
+      if (button) {
+        button.disabled = true;
+        button.dataset.originalLabel = button.textContent;
+        button.textContent = 'Recording…';
+      }
+
+      const payload = {
+        requestId: generateRequestId(),
+        minute,
+        playerOff,
+        playerOn,
+        note,
+        matchId: getActiveMatchId()
+      };
+
+      google.script.run
+        .withSuccessHandler(result => {
+          handleLiveResult(result, 'Substitution recorded successfully');
+          if (result && result.success) {
+            event.target.reset();
+          }
+          resetButton(button);
+        })
+        .withFailureHandler(err => {
+          showLiveFlash('error', 'Failed to record substitution: ' + (err && err.message ? err.message : err));
+          resetButton(button);
+        })
+        .recordLiveMatchSubstitution(payload);
+    }
+
+    function submitNote(event) {
+      event.preventDefault();
+      const minute = (el('#noteMinute')?.value || '').trim();
+      const noteType = (el('#noteType')?.value || '').trim();
+      const player = (el('#notePlayer')?.value || '').trim();
+      const details = (el('#noteDetails')?.value || '').trim();
+
+      if (!noteType) {
+        showLiveFlash('error', 'Select a marker for the note');
+        return;
+      }
+
+      const button = el('#noteSubmit');
+      if (button) {
+        button.disabled = true;
+        button.dataset.originalLabel = button.textContent;
+        button.textContent = 'Saving…';
+      }
+
+      const payload = {
+        requestId: generateRequestId(),
+        minute,
+        noteType,
+        player,
+        details,
+        matchId: getActiveMatchId()
+      };
+
+      google.script.run
+        .withSuccessHandler(result => {
+          handleLiveResult(result, 'Note saved for video editor');
+          if (result && result.success) {
+            event.target.reset();
+          }
+          resetButton(button);
+        })
+        .withFailureHandler(err => {
+          showLiveFlash('error', 'Failed to save note: ' + (err && err.message ? err.message : err));
+          resetButton(button);
+        })
+        .recordLiveMatchNote(payload);
+    }
+
+    function submitStatus(statusId) {
+      if (!statusId) {
+        return;
+      }
+      const button = document.querySelector(`[data-status-btn='${statusId}']`);
+      if (button) {
+        button.disabled = true;
+        button.dataset.originalLabel = button.textContent;
+        button.textContent = 'Posting…';
+      }
+
+      const payload = {
+        requestId: generateRequestId(),
+        statusId,
+        matchId: getActiveMatchId()
+      };
+
+      google.script.run
+        .withSuccessHandler(result => {
+          handleLiveResult(result, `${statusId.replace(/_/g, ' ')} posted`);
+          resetButton(button);
+        })
+        .withFailureHandler(err => {
+          showLiveFlash('error', 'Failed to post status: ' + (err && err.message ? err.message : err));
+          resetButton(button);
+        })
+        .recordLiveMatchStatus(payload);
+    }
+
+    function handleLiveResult(result, successMessage) {
+      if (result && result.duplicate) {
+        showLiveFlash('info', 'Duplicate request ignored (already processed).');
+        loadLiveConsoleState(false);
+        return;
+      }
+
+      if (result && result.success) {
+        showLiveFlash('success', successMessage);
+        loadLiveConsoleState(false);
+      } else {
+        showLiveFlash('error', result && result.error ? result.error : 'Operation failed');
+      }
+    }
+
+    function resetButton(button) {
+      if (!button) {
+        return;
+      }
+      button.disabled = false;
+      button.textContent = button.dataset.originalLabel || button.textContent;
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      initTabs();
+      loadState();
+      const params = new URLSearchParams(window.location.search);
+      const initial = params.get('view') === 'live' ? 'live' : 'control';
+      showView(initial);
+    });
   </script>
 </body>
 </html>

--- a/src/enhanced-events.gs
+++ b/src/enhanced-events.gs
@@ -1101,6 +1101,26 @@ function processSubstitution(minute, playerOff, playerOn, matchId = null) {
 }
 
 /**
+ * Post kick-off status update
+ * @param {string} matchId - Match identifier
+ * @returns {Object} Processing result
+ */
+function postKickOff(matchId = null) {
+  const manager = new EnhancedEventsManager();
+  return manager.processKickOff(matchId);
+}
+
+/**
+ * Post half-time status update
+ * @param {string} matchId - Match identifier
+ * @returns {Object} Processing result
+ */
+function postHalfTime(matchId = null) {
+  const manager = new EnhancedEventsManager();
+  return manager.processHalfTime(matchId);
+}
+
+/**
  * Process second half kick-off (public API)
  * @param {string} matchId - Match identifier
  * @returns {Object} Processing result
@@ -1108,6 +1128,16 @@ function processSubstitution(minute, playerOff, playerOn, matchId = null) {
 function postSecondHalfKickoff(matchId = null) {
   const manager = new EnhancedEventsManager();
   return manager.processSecondHalfKickOff(matchId);
+}
+
+/**
+ * Post full-time status update
+ * @param {string} matchId - Match identifier
+ * @returns {Object} Processing result
+ */
+function postFullTime(matchId = null) {
+  const manager = new EnhancedEventsManager();
+  return manager.processFullTime(matchId);
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a dedicated live match console view to the control panel with scoreboard, status buttons, and goal/card/substitution/note forms
- expose configuration for live console status options, card types, and video note markers via config.js
- implement server handlers that hydrate console state, process submissions with idempotency guards, and log video notes to Live Match Updates
- expose helper wrappers for posting kick-off, half-time, and full-time status events

## Testing
- not run (Apps Script UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d4a4d0440c8329ae8dde87bd779260