### PR TITLE
Refactor: use getSheet helper for standalone script access

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -589,7 +589,7 @@ function getPlayersForWeb() {
     }
 
     // Fallback to basic implementation
-    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Players');
+    const sheet = getSheet().getSheetByName('Players');
     if (!sheet) {
       return [];
     }
@@ -627,8 +627,8 @@ function savePlayersFromWeb(players) {
     }
 
     // Fallback to basic implementation
-    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Players') ||
-                  SpreadsheetApp.getActiveSpreadsheet().insertSheet('Players');
+    const spreadsheet = getSheet();
+    const sheet = spreadsheet.getSheetByName('Players') || spreadsheet.insertSheet('Players');
 
     // Clear and write headers if needed
     if (sheet.getLastRow() === 0) {
@@ -772,7 +772,7 @@ function getRecentEventsForWeb(limit = 10) {
     }
 
     // Fallback implementation
-    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Events');
+    const sheet = getSheet().getSheetByName('Events');
     if (!sheet || sheet.getLastRow() <= 1) {
       return [];
     }

--- a/src/main.gs
+++ b/src/main.gs
@@ -1185,7 +1185,10 @@ function testSheetOperations() {
     
     // Clean up test sheet
     try {
-      SpreadsheetApp.getActiveSpreadsheet().deleteSheet(sheet);
+      const parentSpreadsheet = sheet && typeof sheet.getParent === 'function' ? sheet.getParent() : null;
+      if (parentSpreadsheet) {
+        parentSpreadsheet.deleteSheet(sheet);
+      }
     } catch (cleanupError) {
       // Ignore cleanup errors
     }

--- a/src/monitoring-alerting-system.gs
+++ b/src/monitoring-alerting-system.gs
@@ -225,9 +225,9 @@ class MonitoringAlertingSystem {
 
     try {
       // Test sheet access
-      const testSheet = SpreadsheetApp.getActiveSpreadsheet();
+      const testSheet = getSheet();
       if (!testSheet) {
-        throw new Error('Cannot access active spreadsheet');
+        throw new Error('Cannot access configured spreadsheet');
       }
 
       // Test sheet operations

--- a/src/system-health.gs
+++ b/src/system-health.gs
@@ -31,11 +31,23 @@ function runSystemHealthCheck() {
  */
 function checkSheets() {
   try {
-    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const ss = getSheet();
     if (!ss) throw new Error("Spreadsheet not found.");
     Logger.log("✅ Spreadsheet accessible: " + ss.getName());
   } catch (e) {
     Logger.log("❌ Spreadsheet access error: " + e.message);
+  }
+}
+
+/**
+ * Validates the centralized getSheet helper.
+ */
+function testGetSheet() {
+  try {
+    const ss = getSheet();
+    Logger.log("✅ Sheet title: " + ss.getName());
+  } catch (e) {
+    Logger.log("❌ getSheet failed: " + e.message);
   }
 }
 
@@ -53,7 +65,7 @@ function checkSheetTabs() {
     "League Canva Map"
   ];
 
-  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const ss = getSheet();
   requiredTabs.forEach(tabName => {
     const sheet = ss.getSheetByName(tabName);
     if (sheet) {
@@ -147,7 +159,7 @@ function testRefreshToday() {
  */
 function simulateLiveMatchUpdate() {
   try {
-    const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("Live Match Updates");
+    const sheet = getSheet().getSheetByName("Live Match Updates");
     if (!sheet) throw new Error("Live Match Updates tab missing.");
 
     const lastRow = sheet.getLastRow() + 1;

--- a/src/utils.gs
+++ b/src/utils.gs
@@ -62,7 +62,7 @@ const SheetUtils = {
     let failure = null;
 
     try {
-      const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+      const spreadsheet = getSheet();
       sheet = spreadsheet.getSheetByName(sheetName);
 
       if (!sheet) {


### PR DESCRIPTION
## Summary
- add a centralized SHEET_ID resolver and getSheet helper in config.gs for standalone Apps Script projects
- update sheet access across utilities, web handlers, monitoring, and health checks to use the shared getSheet helper
- add a system health helper to verify getSheet resolves the linked spreadsheet

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d5aa26c09883299db0c49fced38357