### PR TITLE
Fix club name UI IDs to avoid collisions

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -32,7 +32,7 @@
                 <div class="header-content">
                     <div class="club-info">
                         <img id="club-badge" class="club-badge" src="" alt="Badge" style="display: none;">
-                        <h1 id="club-name" class="club-name">Club Console</h1>
+                        <h1 id="club-name-display" class="club-name">Club Console</h1>
                     </div>
                     <div class="connection-indicator" id="connection-indicator">
                         <span class="connection-dot"></span>

--- a/src/scripts.html
+++ b/src/scripts.html
@@ -104,7 +104,7 @@ function setupSetupListeners() {
     }
 
     // Club name and badge
-    const clubName = document.getElementById('club-name');
+    const clubName = document.getElementById('club-name-input');
     const badgeUrl = document.getElementById('badge-url');
 
     if (clubName) {
@@ -291,11 +291,11 @@ async function loadConfiguration() {
 
 function updateUIWithConfig(config) {
     // Update header
-    const clubName = document.getElementById('club-name');
+    const clubNameDisplay = document.getElementById('club-name-display');
     const clubBadge = document.getElementById('club-badge');
 
-    if (clubName && config.CLUB_NAME) {
-        clubName.textContent = config.CLUB_NAME;
+    if (clubNameDisplay) {
+        clubNameDisplay.textContent = config.CLUB_NAME || 'Club Console';
     }
 
     if (clubBadge && config.BADGE_URL) {
@@ -320,7 +320,7 @@ function updateUIWithConfig(config) {
 
 function updateSetupForm(config) {
     const fields = {
-        'club-name': config.CLUB_NAME,
+        'club-name-input': config.CLUB_NAME,
         'primary-color': config.PRIMARY_HEX,
         'primary-color-text': config.PRIMARY_HEX,
         'secondary-color': config.SECONDARY_HEX,
@@ -368,7 +368,7 @@ async function saveConfiguration() {
         showStatus('Saving configuration...', 'info');
 
         const configData = {
-            CLUB_NAME: document.getElementById('club-name')?.value || '',
+            CLUB_NAME: document.getElementById('club-name-input')?.value || '',
             PRIMARY_HEX: document.getElementById('primary-color')?.value || '#FF0000',
             SECONDARY_HEX: document.getElementById('secondary-color')?.value || '#FFFFFF',
             BADGE_URL: document.getElementById('badge-url')?.value || '',
@@ -818,7 +818,7 @@ function updateBrandPreview() {
     const previewBadge = document.getElementById('preview-badge');
     const brandPreview = document.getElementById('brand-preview');
 
-    const clubName = document.getElementById('club-name')?.value || 'Club Name';
+    const clubName = document.getElementById('club-name-input')?.value || 'Club Name';
     const badgeUrl = document.getElementById('badge-url')?.value;
     const primaryColor = document.getElementById('primary-color')?.value;
     const secondaryColor = document.getElementById('secondary-color')?.value;

--- a/src/setup.html
+++ b/src/setup.html
@@ -7,7 +7,7 @@
         <div class="card-body">
             <div class="form-group">
                 <label class="form-label">Club Name</label>
-                <input type="text" id="club-name" class="form-input" placeholder="Enter club name">
+                <input type="text" id="club-name-input" class="form-input" placeholder="Enter club name">
             </div>
 
             <div class="form-group">


### PR DESCRIPTION
## Summary
- rename the header club name element to `club-name-display`
- give the setup form club name input a dedicated `club-name-input` id
- update client scripts to read from/write to the new identifiers for config and preview updates

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9af63bd4c8329988316bfa79af148