### PR TITLE
Rename runtime config accessor to avoid config path collision

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -845,7 +845,7 @@ function handleAddFixture(params) {
 function getDashboardStats() {
   try {
     // Use config-aware sheet access
-    const config = getConfig();
+    const config = getRuntimeConfig();
     const playersSheet = SheetUtils.getSheet('Players');
     const fixturesSheet = SheetUtils.getSheet('Fixtures');
     const resultsSheet = SheetUtils.getSheet('Results');
@@ -1012,7 +1012,7 @@ function testDynamicConfigSystem() {
 
   try {
     // Test 1: Config loading
-    const config = getConfig();
+    const config = getRuntimeConfig();
     console.log('✅ Config loaded:', config.TEAM_NAME);
 
     // Test 2: Template rendering

--- a/src/calendar-integration.gs
+++ b/src/calendar-integration.gs
@@ -47,7 +47,7 @@ const CALENDAR_CONFIG = {
  */
 function getClubCalendar() {
   try {
-    const config = getConfig();
+    const config = getRuntimeConfig();
     const calendarName = `${config.TEAM_NAME} - Fixtures & Events`;
 
     // Try to find existing calendar
@@ -84,7 +84,7 @@ function getClubCalendar() {
  */
 function addFixtureToCalendar(fixtureData) {
   try {
-    const config = getConfig();
+    const config = getRuntimeConfig();
     const calendar = getClubCalendar();
 
     // Parse fixture date and time
@@ -247,7 +247,7 @@ function determineEventLocation(fixtureData, config) {
 function updateCalendarEvent(fixtureData, opposition) {
   try {
     const calendar = getClubCalendar();
-    const config = getConfig();
+    const config = getRuntimeConfig();
 
     // Find existing event
     const startDate = parseUKDate(fixtureData.date);
@@ -309,7 +309,7 @@ function updateCalendarEvent(fixtureData, opposition) {
 function cancelCalendarEvent(opposition, originalDate) {
   try {
     const calendar = getClubCalendar();
-    const config = getConfig();
+    const config = getRuntimeConfig();
 
     // Find event to cancel
     const startDate = parseUKDate(originalDate);
@@ -538,7 +538,7 @@ function findCalendarEvent(opposition, date) {
  */
 function exportCalendarAsICS() {
   try {
-    const config = getConfig();
+    const config = getRuntimeConfig();
     const calendar = getClubCalendar();
 
     // Get current season events

--- a/src/comprehensive-tests.gs
+++ b/src/comprehensive-tests.gs
@@ -550,7 +550,7 @@ function runPrivacyTests() {
 function runIntegrationTests() {
   const tests = {
     testConfigSystemIntegration: () => {
-      const config = getConfig();
+      const config = getRuntimeConfig();
       AdvancedTestFramework.assertNotNull(config, 'Config should load');
       AdvancedTestFramework.assertNotNull(config.SYSTEM, 'System config should exist');
     },
@@ -676,7 +676,7 @@ function runAllComprehensiveTests() {
 function quickComprehensiveTest() {
   try {
     // Quick validation of core systems
-    const config = getConfig();
+    const config = getRuntimeConfig();
     if (!config) throw new Error('Config system failed');
 
     const health = HealthCheck.quickHealthCheck();

--- a/src/consent-management.gs
+++ b/src/consent-management.gs
@@ -40,7 +40,7 @@ class ConsentManager {
    */
   static createConsentForm(playerData) {
     try {
-      const config = getConfig();
+      const config = getRuntimeConfig();
       const template = this.buildConsentFormTemplate(playerData, config);
 
       const form = {
@@ -218,7 +218,7 @@ class ConsentManager {
    * Generates GDPR rights information
    */
   static generateRightsInformation() {
-    const config = getConfig();
+    const config = getRuntimeConfig();
 
     return {
       rightToAccess: 'You can request a copy of your personal data we hold.',
@@ -510,7 +510,7 @@ class ConsentManager {
    * Sends consent form email to player/parent
    */
   static sendConsentFormEmail(form, pdfUrl) {
-    const config = getConfig();
+    const config = getRuntimeConfig();
     const recipient = form.ageCategory === this.getAgeCategories().MINOR ?
       form.parentEmail : form.contactEmail;
 
@@ -567,7 +567,7 @@ class ConsentManager {
    * Generates submission URL for online form completion
    */
   static generateSubmissionUrl() {
-    const config = getConfig();
+    const config = getRuntimeConfig();
     return `${config.WEB_APP_URL}?action=consent_form`;
   }
 

--- a/src/customer-installer.gs
+++ b/src/customer-installer.gs
@@ -507,7 +507,7 @@ function performInstallationHealthCheck() {
 
   // Check 4: System Functions
   try {
-    const hasCoreFunction = typeof getConfig === 'function';
+    const hasCoreFunction = typeof getRuntimeConfig === 'function';
     checks.push({ name: 'Core Functions', pass: hasCoreFunction, weight: 20 });
     if (hasCoreFunction) score += 20;
   } catch (error) {

--- a/src/customer_setup_wizard_svc.gs
+++ b/src/customer_setup_wizard_svc.gs
@@ -483,7 +483,7 @@ function buildDeploymentResult(success, results, message) {
  */
 function validateSystemConfiguration() {
   try {
-    const config = getConfig();
+    const config = getRuntimeConfig();
 
     // Check required configuration
     const requiredKeys = ['TEAM_NAME', 'TEAM_SHORT', 'LEAGUE_NAME', 'PRIMARY_COLOR'];
@@ -700,7 +700,7 @@ function testAutomationPipeline() {
  */
 function generateCustomerDashboard() {
   try {
-    const config = getConfig();
+    const config = getRuntimeConfig();
 
     // Create dashboard URL
     const dashboardUrl = getWebAppUrl() + '?dashboard=true';

--- a/src/dynamic-config.gs
+++ b/src/dynamic-config.gs
@@ -47,12 +47,12 @@ const DEFAULT_CONFIG_VALUES = {
 // ==================== CORE CONFIG FUNCTIONS ====================
 
 /**
- * Get configuration with caching
+ * Get runtime configuration with caching
  * @param {Object} opts - Options
  * @param {boolean} opts.forceRefresh - Force refresh from sheet
  * @returns {Object} Configuration object
  */
-function getConfig(opts = {}) {
+function getRuntimeConfig(opts = {}) {
   const now = Date.now();
   const props = PropertiesService.getScriptProperties();
 
@@ -84,11 +84,11 @@ function getConfig(opts = {}) {
 }
 
 /**
- * Shorthand for getConfig()
+ * Shorthand for getRuntimeConfig()
  * @returns {Object} Configuration object
  */
 function cfg() {
-  return getConfig();
+  return getRuntimeConfig();
 }
 
 /**
@@ -97,7 +97,7 @@ function cfg() {
  * @returns {Object} Configuration with overrides applied
  */
 function getConfigWithQuery_(e) {
-  const base = getConfig();
+  const base = getRuntimeConfig();
 
   if (e && e.parameter) {
     // Allow preview overrides
@@ -299,7 +299,7 @@ function renderHtml_(fileName, opts = {}) {
     } = opts;
 
     // Get configuration
-    const cfg = config || getConfig();
+    const cfg = config || getRuntimeConfig();
 
     // Create template
     const template = HtmlService.createTemplateFromFile(fileName);
@@ -358,7 +358,7 @@ function include(filename) {
  * @returns {Object} Complete payload with config
  */
 function buildConfiguredPayload(eventData) {
-  const config = getConfig();
+  const config = getRuntimeConfig();
 
   return {
     // Event data
@@ -397,7 +397,7 @@ function buildConfiguredPayload(eventData) {
  * @returns {Object} Complete configuration
  */
 function getAllConfig() {
-  return getConfig();
+  return getRuntimeConfig();
 }
 
 /**
@@ -415,7 +415,7 @@ function clearConfigCache() {
  */
 function validateConfig() {
   try {
-    const config = getConfig();
+    const config = getRuntimeConfig();
 
     return {
       valid: true,
@@ -441,7 +441,7 @@ function testConfigSystem() {
 
   try {
     // Test 1: Load config
-    const config = getConfig();
+    const config = getRuntimeConfig();
     console.log('✅ Config loaded successfully');
 
     // Test 2: Validate required keys
@@ -449,11 +449,11 @@ function testConfigSystem() {
     console.log('✅ Required keys validation passed');
 
     // Test 3: Cache functionality
-    const config2 = getConfig(); // Should use cache
+    const config2 = getRuntimeConfig(); // Should use cache
     console.log('✅ Cache functionality working');
 
     // Test 4: Force refresh
-    const config3 = getConfig({forceRefresh: true});
+    const config3 = getRuntimeConfig({forceRefresh: true});
     console.log('✅ Force refresh working');
 
     return {

--- a/src/fa-email-integration.gs
+++ b/src/fa-email-integration.gs
@@ -52,7 +52,7 @@ function checkForNewFAEmails() {
   console.log('📧 Checking for new FA fixture emails...');
 
   try {
-    const config = getConfig();
+    const config = getRuntimeConfig();
     const results = {
       emailsChecked: 0,
       fixturesFound: 0,
@@ -119,7 +119,7 @@ function checkForNewFAEmails() {
  * @returns {string} Gmail search query
  */
 function buildFAEmailSearchQuery() {
-  const config = getConfig();
+  const config = getRuntimeConfig();
 
   // Get date range (last 30 days)
   const thirtyDaysAgo = new Date();
@@ -190,7 +190,7 @@ function parseFixtureFromEmail(message) {
  * @returns {string} Opposition team name
  */
 function extractOpposition(subject, body) {
-  const config = getConfig();
+  const config = getRuntimeConfig();
   const ourTeam = config.TEAM_NAME;
   const ourShortName = config.TEAM_SHORT;
 
@@ -318,7 +318,7 @@ function extractKickOffTime(subject, body) {
  * @returns {string} Venue information
  */
 function extractVenue(subject, body) {
-  const config = getConfig();
+  const config = getRuntimeConfig();
   const text = `${subject} ${body}`;
 
   // Venue patterns
@@ -542,7 +542,7 @@ function addFixtureToSheet(fixtureData) {
  */
 function addFixtureToCalendar(fixtureData) {
   try {
-    const config = getConfig();
+    const config = getRuntimeConfig();
 
     // Parse date and time
     const matchDate = parseUKDate(fixtureData.date);

--- a/src/feature-toggle-system.gs
+++ b/src/feature-toggle-system.gs
@@ -668,7 +668,7 @@ class FeatureToggleSystem {
    */
   static sendKillSwitchAlert(featureKey, reason) {
     try {
-      const config = getConfig();
+      const config = getRuntimeConfig();
       const alertEmail = config.ADMIN_EMAIL || config.CONTACT_EMAIL;
 
       if (alertEmail) {

--- a/src/health-check.gs
+++ b/src/health-check.gs
@@ -127,7 +127,7 @@ class HealthCheck {
    */
   static checkConfiguration() {
     try {
-      const config = getConfig();
+      const config = getRuntimeConfig();
       const requiredKeys = ['SYSTEM.CLUB_NAME', 'SYSTEM.VERSION'];
 
       const missingKeys = requiredKeys.filter(key => {
@@ -227,7 +227,7 @@ class HealthCheck {
   static quickHealthCheck() {
     try {
       const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
-      const config = getConfig();
+      const config = getRuntimeConfig();
 
       return {
         status: 'healthy',

--- a/src/main.gs
+++ b/src/main.gs
@@ -430,7 +430,7 @@ function setupSystemTriggers() {
  */
 function getQuickStatus() {
   try {
-    const config = getConfig();
+    const config = getRuntimeConfig();
     const health = HealthCheck.quickHealthCheck();
 
     return {

--- a/src/practical-tests.gs
+++ b/src/practical-tests.gs
@@ -94,7 +94,7 @@ class SimpleTestFramework {
 function testConfigLoading() {
   SimpleTestFramework.runTest('Config Loading', () => {
     // Test config can be loaded
-    const config = getConfig();
+    const config = getRuntimeConfig();
     SimpleTestFramework.assertNotNull(config, 'Config should load successfully');
 
     // Test required keys are present
@@ -317,7 +317,7 @@ function runSingleTest(testName) {
 function smokeTest() {
   try {
     // Test 1: Config loads
-    const config = getConfig();
+    const config = getRuntimeConfig();
     if (!config) throw new Error('Config failed to load');
 
     // Test 2: Health check runs

--- a/src/production-monitoring.gs
+++ b/src/production-monitoring.gs
@@ -240,7 +240,7 @@ class ProductionMonitoringManager {
 
   static checkConfigurationHealth() {
     try {
-      const config = getConfig();
+      const config = getRuntimeConfig();
       const check = {
         name: 'Configuration System',
         status: 'healthy',

--- a/src/scripts.html
+++ b/src/scripts.html
@@ -275,7 +275,7 @@ function switchTab(tabName) {
 
 async function loadConfiguration() {
     try {
-        const config = await callServerFunction('getConfig');
+        const config = await callServerFunction('getRuntimeConfig');
         window.ClubConsole.config = config;
 
         // Update UI with config values

--- a/src/user-menu-functions.gs
+++ b/src/user-menu-functions.gs
@@ -349,7 +349,7 @@ function testSystemQuick() {
   try {
     const tests = {
       logger: typeof logger !== 'undefined',
-      config: typeof getConfig !== 'undefined',
+      config: typeof getRuntimeConfig !== 'undefined',
       sheetUtils: typeof SheetUtils !== 'undefined',
       eventsManager: typeof EnhancedEventsManager !== 'undefined',
       batchManager: typeof BatchFixturesManager !== 'undefined',

--- a/src/working-monitoring.gs
+++ b/src/working-monitoring.gs
@@ -115,7 +115,7 @@ class WorkingMonitoring {
       // Test 3: Can we load the config?
       healthResults.checks++;
       try {
-        const config = getConfig();
+        const config = getRuntimeConfig();
         if (config && config.SYSTEM && config.SYSTEM.CLUB_NAME) {
           healthResults.passed++;
           healthResults.details.push({
@@ -236,11 +236,11 @@ class WorkingMonitoring {
     try {
       // Test 1: Config loading speed
       const configStart = Date.now();
-      const config = getConfig();
+      const config = getRuntimeConfig();
       const configTime = Date.now() - configStart;
 
       performanceTests.push({
-        function: 'getConfig',
+        function: 'getRuntimeConfig',
         timeMs: configTime,
         status: configTime < 1000 ? 'fast' : configTime < 3000 ? 'acceptable' : 'slow'
       });
@@ -307,7 +307,7 @@ class WorkingMonitoring {
 
       // Simple error tracking - check if we can execute basic functions
       const testFunctions = [
-        () => getConfig(),
+        () => getRuntimeConfig(),
         () => SpreadsheetApp.getActiveSpreadsheet().getName(),
         () => new Date().toISOString()
       ];


### PR DESCRIPTION
## Summary
- rename the dynamic runtime config accessor to `getRuntimeConfig` and update the `cfg()` helper accordingly
- update backend modules and tests to call `getRuntimeConfig` whenever the full configuration object is required
- adjust the web UI to request `getRuntimeConfig` so CSS variables continue receiving the expected hex values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9af64a1b08329a2d17bb9b576963d