### PR TITLE
Add governance and i18n documentation resources

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -1,0 +1,68 @@
+# API Contract
+
+This document summarizes the interfaces exposed by the Automation Script
+project. Although Apps Script primarily operates through triggers and
+spreadsheet interactions, several entry points are treated as public APIs for
+integrators.
+
+## Web App Endpoint
+
+- **URL**: Deployment-specific URL managed by CI (see
+  `WEBAPP_DEPLOYMENT_ID`).
+- **Method**: `GET`
+- **Handler**: `doGet`
+- **Response**: Renders `index_ui.html`, the primary user interface.
+- **Notes**: Inputs are sanitized before rendering. Do not expose Script
+  Properties or sensitive configuration values directly to the client.
+
+### POST Handler
+
+- **Method**: `POST`
+- **Handler**: `doPost`
+- **Request Body**: Plain text or JSON payloads defined by the invoking
+  service.
+- **Response**: `text/plain` with the message `OK` for successful requests.
+- **Error Handling**: Errors should be thrown with descriptive messages and
+  will surface as HTTP 500 responses. Consumers should implement retries with
+  backoff.
+
+## Install Function
+
+- **Function**: `installForCustomer`
+- **Purpose**: Reads the Sheet Config tab, validates required keys, persists
+  configuration to Script Properties, and ensures triggers are created
+  idempotently.
+- **Input**: None (relies on the active spreadsheet context).
+- **Output**: Returns the string `Install OK` on success.
+- **Failure Modes**:
+  - Missing Sheet Config tab.
+  - Required keys (`SHEET_ID`, `ENV`, `SYSTEM_VERSION`) not present.
+
+## Scheduled Jobs
+
+- **Functions**: `runHealthCheck`, `runWeeklyJobs`, and any future triggers
+  created via `ensureTimeTrigger`.
+- **Invocation**: Managed by time-based triggers. Each handler must be
+  idempotent and log structured success/failure messages.
+- **Retry Strategy**: Trigger handlers should catch and log recoverable errors,
+  then rethrow to allow Apps Script's native retry behavior.
+
+## HTTP Utility
+
+- **Function**: `fetchJson(url, options, tries, delay)`
+- **Purpose**: Standardized outbound HTTP client with exponential backoff, JSON
+  parsing, and robust error signaling.
+- **Behavior**:
+  - Retries up to `tries` times (default 4) with a base delay provided in
+    milliseconds.
+  - Throws an error after the final attempt with context about the failing URL.
+
+## Version Probe
+
+- **Function**: `SA_Version`
+- **Purpose**: Returns the current system version from Script Properties to
+  assist with deployment validation and monitoring.
+- **Response**: Version string or `unknown` when the property is not set.
+
+For any additions or changes to these interfaces, update this contract and
+notify downstream consumers via the changelog or release notes.

--- a/CODEX_INSTRUCTIONS.md
+++ b/CODEX_INSTRUCTIONS.md
@@ -1,0 +1,48 @@
+# Codex Collaboration Guidelines
+
+These guidelines explain how GitHub Copilot / OpenAI Codex agents should
+operate when assisting with this repository.
+
+## Mission
+
+- Provide concise, actionable suggestions that respect the project's
+  configuration philosophy (Sheet Config tab → Script Properties → runtime
+  reads).
+- Keep generated code modular by feature and avoid introducing new dependencies
+  without prior discussion.
+
+## Interaction Rules
+
+1. **Honor Existing Contracts** – Review `API_CONTRACT.md`,
+   `README-Developer.md`, and the snippets in `README.md` before drafting
+   changes.
+2. **Avoid Sensitive Data** – Never invent or expose production sheet IDs,
+   OAuth tokens, or deployment IDs. Use placeholders or configuration lookups
+   instead.
+3. **Idempotence First** – When suggesting installer or trigger updates, ensure
+   the patterns remain idempotent to prevent duplicate jobs.
+4. **Respect Logging Policy** – Suggest structured logs that redact or hash
+   sensitive context.
+
+## Code Generation Standards
+
+- Prefer descriptive function names ending in `_svc` for server logic and `_ui`
+  for HTML templates.
+- Leverage helper utilities (e.g., `fetchJson`) instead of duplicating HTTP
+  logic.
+- Validate headers before reading spreadsheet data; fail fast with clear error
+  messages.
+- Use modern JavaScript (const/let, arrow functions where appropriate) and
+  avoid deprecated Apps Script APIs.
+
+## Review Checklist for Generated Changes
+
+- [ ] Does the change keep configuration in the Sheet Config tab or Script
+  Properties?
+- [ ] Are spreadsheet operations batched using `getValues()`/`setValues()`?
+- [ ] Do HTTP calls use the enterprise client pattern with backoff and safe
+  parsing?
+- [ ] Are triggers created or updated via the idempotent helpers?
+
+Following these instructions ensures automated assistance remains aligned with
+the maintainers' expectations.

--- a/CODEX_STEPS.md
+++ b/CODEX_STEPS.md
@@ -1,0 +1,42 @@
+# Codex Playbook
+
+Use this checklist when generating or reviewing changes for the Automation
+Script project.
+
+## Before You Start
+
+1. Read the latest task description and confirm the target files.
+2. Review `README-Developer.md` and `CODEX_INSTRUCTIONS.md` to understand
+   constraints.
+3. Inspect existing modules in `src/` to identify reusable helpers.
+
+## During Implementation
+
+1. **Plan** – Outline the minimal set of files and functions that need updates.
+2. **Edit** – Apply changes using modern JavaScript conventions and keep
+   modules focused.
+3. **Validate** – Re-run relevant Apps Script functions locally or provide
+   reasoning why runtime behavior remains correct.
+4. **Document** – Update related markdown files or inline comments when
+   behavior changes.
+
+## Pre-Commit Review
+
+- [ ] Confirm configuration values are sourced from Script Properties or the
+  Sheet Config tab.
+- [ ] Ensure new triggers use `ensureTimeTrigger` or another idempotent
+  helper.
+- [ ] Verify HTTP calls rely on `fetchJson` (or comparable enterprise client)
+  with retries and safe parsing.
+- [ ] Check that no PII is written to logs or documentation.
+- [ ] Run linting, tests, or validation steps requested in the task.
+
+## Pull Request Checklist
+
+1. Summarize the problem and solution in the PR description.
+2. List any new scopes or deployment actions required.
+3. Attach screenshots or logs that demonstrate acceptance criteria.
+4. Tag reviewers who own the impacted modules.
+
+Following these steps keeps contributions predictable and aligned with the
+automation platform's standards.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing Guide
+
+Thank you for your interest in improving the Automation Script project. This
+guide explains how to set up your environment, make meaningful changes, and
+submit a high-quality pull request.
+
+## Getting Started
+
+1. Fork the repository and clone your fork locally.
+2. Install the Google Apps Script CLI (`@google/clasp`) and authenticate with
+   the service account used by CI.
+3. Run `npm install` if your change depends on Node tooling (for example,
+   linting or bundling helpers).
+4. Work from a feature branch named after the issue or enhancement you are
+   addressing (e.g., `feature/sheet-sync-improvements`).
+
+## Development Workflow
+
+- Keep edits inside the `src/` directory unless you are updating documentation
+  or CI assets.
+- Follow the configuration contract described in `README-Developer.md`—store
+  customer-specific values in the Sheet Config tab and surface runtime settings
+  via Script Properties.
+- Prefer small, focused commits that are easy to review. Reference the related
+  issue in your commit message when possible.
+
+## Coding Standards
+
+- Use modern Apps Script (V8) syntax and avoid introducing TypeScript unless
+  explicitly requested.
+- Group functionality into feature-focused modules: server code in `*_svc.gs`,
+  HTML UI in `*_ui.html`.
+- Batch spreadsheet reads and writes with `getValues()`/`setValues()` over full
+  ranges; never loop over individual cells when a range operation will do.
+- For outbound HTTP requests, apply the enterprise client pattern (timeouts,
+  retries with exponential backoff, and structured error handling).
+
+## Testing and Validation
+
+- Use the Apps Script editor or clasp-driven tests to validate new triggers,
+  installers, and HTTP integrations.
+- Run any relevant local checks (e.g., linting, unit tests) before submitting.
+- If you change scopes, note the update clearly in your pull request body so
+  reviewers can plan for re-authorization.
+
+## Submitting a Pull Request
+
+1. Ensure your branch is rebased on the latest `main` branch.
+2. Provide a concise summary of the change, highlighting user-facing impacts
+   and any deployment actions.
+3. Include acceptance criteria or test evidence (screenshots, logs, or sheet
+   snapshots) demonstrating that the change meets expectations.
+4. Request review from the maintainers listed in `README-Developer.md` or the
+   code owners for the touched areas.
+
+Following these guidelines helps us ship reliable automation for everyone who
+depends on this project. We appreciate your contributions!

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,56 @@
+# Privacy Notice
+
+This document explains how the Automation Script project handles data while
+automating Google Workspace workflows. The focus is on transparency and
+minimizing the amount of information we process.
+
+## Data Sources
+
+- **Google Sheets** – Configuration and operational data reside in
+  customer-owned spreadsheets. The script reads and writes ranges defined by
+  the Sheet Config tab and never stores sheet contents outside Google
+  Workspace.
+- **Google Drive** – Files may be accessed when workflows require reading
+  templates or exporting reports. Access is limited to the permissions granted
+  to the Apps Script project.
+- **External APIs** – When integrations are configured, the script
+  communicates with the endpoints listed in the Sheet Config tab. All outbound
+  requests are authenticated using credentials supplied by the customer.
+
+## Data Handling Principles
+
+1. **Least Privilege** – The script requests only the OAuth scopes required to
+   execute the documented workflows.
+2. **No Persistent Storage** – We do not persist customer data on external
+   servers. Script Properties store configuration keys only; sensitive values
+   should be rotated by the customer.
+3. **Secure Logging** – Operational logs avoid including personally
+   identifiable information. When debugging requires context, sensitive values
+   are hashed or redacted.
+4. **Idempotent Operations** – Installers and triggers are designed to re-run
+   safely, ensuring repeated executions do not leak or duplicate data.
+
+## Access Controls
+
+- Contributors interact with production resources only through the established
+  CI pipeline and service accounts.
+- Manual testing should use sandbox spreadsheets or copies of production data
+  with sensitive fields removed.
+- Customers maintain control of their configuration sheets and can revoke
+  access by removing the Apps Script project or changing sharing settings.
+
+## Incident Response
+
+If you suspect a privacy incident:
+
+1. Immediately disable triggers that interact with the impacted data source.
+2. Notify the maintainers listed in `README-Developer.md` with a summary of the
+   issue.
+3. Capture relevant logs while respecting the no-PII policy, and document
+   remediation steps in the issue tracker.
+
+## Contact
+
+For privacy-related inquiries, open an issue in the repository or contact the
+project maintainers directly via the support channels outlined in
+`README-Customer.md`.

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -1,0 +1,40 @@
+# Internationalization Guide
+
+This directory stores locale assets that extend the Automation Script project
+to multiple languages.
+
+## Principles
+
+- **Centralize Strings** – Keep user-facing copy in locale files instead of
+  scattering text across Apps Script modules or HTML templates.
+- **Sheet-Driven Config** – Reference translation keys from the Sheet Config tab
+  or Script Properties so customers can control the active locale without code
+  changes.
+- **Fallbacks** – Always provide an English fallback. If a translation is
+  missing, the app should gracefully degrade to the default text.
+
+## Recommended Structure
+
+```text
+i18n/
+├── README.md
+├── en.json
+├── es.json
+└── ...additional locale files
+```
+
+- Store each locale in a JSON file keyed by message identifiers.
+- Keep keys descriptive (e.g., `install.success`, `error.missingConfig`).
+- Document any pluralization or formatting requirements inside comments at the
+  top of the file.
+
+## Workflow
+
+1. Product or support teams propose translation updates.
+2. Contributors update the relevant locale files and confirm formatting via the
+   Apps Script UI.
+3. Update acceptance tests or manual checklists to reference the new keys.
+4. Include screenshots for languages with right-to-left scripts when applicable.
+
+Maintaining translations alongside the automation code ensures customers
+receive consistent experiences across regions.


### PR DESCRIPTION
## Summary
- add contributor onboarding, privacy, and API contract documentation at the repository root
- publish Codex collaboration guidelines and step-by-step checklist for automated assistance
- introduce an internationalization guide to the new `i18n/` directory

## Testing
- `npx markdownlint-cli2 CONTRIBUTING.md PRIVACY.md API_CONTRACT.md CODEX_INSTRUCTIONS.md CODEX_STEPS.md i18n/README.md`


------
https://chatgpt.com/codex/tasks/task_e_68db244a620c832985b403e0f808ac3b