### PR TITLE
Add OpenAPI validation and docs compliance workflows

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -1,0 +1,25 @@
+name: API Contract Validation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint OpenAPI specification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install OpenAPI validator
+        run: npm install -g @stoplight/spectral-cli
+
+      - name: Lint openapi.yaml
+        run: spectral lint openapi.yaml

--- a/.github/workflows/docs-presence.yml
+++ b/.github/workflows/docs-presence.yml
@@ -1,0 +1,92 @@
+name: Documentation Bundle Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  docs:
+    name: Validate documentation bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure required documentation files exist
+        run: |
+          set -euo pipefail
+          files=(
+            'AGENT.md'
+            'README.md'
+            'CONTRIBUTING.md'
+            'PRIVACY.md'
+            'API_CONTRACT.md'
+            'CODEX_INSTRUCTIONS.md'
+            'CODEX_STEPS.md'
+            'SECURITY.md'
+            'i18n/README.md'
+            'openapi.yaml'
+          )
+          missing=()
+          for file in "${files[@]}"; do
+            if [ ! -s "$file" ]; then
+              echo "Missing or empty required documentation file: $file"
+              missing+=("$file")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "Documentation bundle validation failed." >&2
+            exit 1
+          fi
+
+      - name: Verify OpenAPI version bump on spec changes
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA='${{ github.event.pull_request.base.sha }}'
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            BASE_SHA='${{ github.event.before }}'
+          else
+            BASE_SHA=""
+          fi
+
+          if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            echo "No base revision available; skipping OpenAPI version check."
+            exit 0
+          fi
+
+          if git diff --quiet "$BASE_SHA"..HEAD -- openapi.yaml; then
+            echo "No OpenAPI changes detected."
+            exit 0
+          fi
+
+          if ! git show "$BASE_SHA:openapi.yaml" > /tmp/base_openapi.yaml 2>/dev/null; then
+            echo "Base openapi.yaml not found; skipping version check."
+            exit 0
+          fi
+
+          python -m pip install --quiet pyyaml
+
+          CURRENT_VERSION=$(python - <<'PY'
+import yaml
+with open('openapi.yaml', 'r', encoding='utf-8') as fh:
+    print(yaml.safe_load(fh)['info']['version'])
+PY
+)
+
+          PREVIOUS_VERSION=$(python - <<'PY'
+import sys, yaml
+with open('/tmp/base_openapi.yaml', 'r', encoding='utf-8') as fh:
+    print(yaml.safe_load(fh)['info']['version'])
+PY
+)
+
+          if [ "$CURRENT_VERSION" = "$PREVIOUS_VERSION" ]; then
+            echo "openapi.yaml changed but info.version was not bumped." >&2
+            exit 1
+          fi
+
+          echo "OpenAPI version bumped from $PREVIOUS_VERSION to $CURRENT_VERSION."


### PR DESCRIPTION
## What changed
- add API contract validation workflow using Spectral to lint `openapi.yaml`
- add documentation bundle workflow to verify required files and ensure version bumps when the API contract changes

## Why
- enforce automated OpenAPI contract validation
- guarantee the documentation bundle remains present and versioned alongside contract updates

## Testing
- [ ] clasp status clean
- [ ] Ran SA_Version() after deploy
- [ ] Manual testing completed

## Impact
- [x] No secrets changed
- [x] Backward compatible
- [x] No breaking changes

## Deployment Notes
- [x] Ready for automatic deployment via GitHub Actions
- [ ] Make.com webhooks tested (if applicable)
- [ ] Apps Script permissions verified (if new APIs added)

------
https://chatgpt.com/codex/tasks/task_e_68db27cefb848329861ae60b20d389fc