### PR TITLE
chore: add CODEOWNERS for specs and docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# CODEOWNERS for critical specs, governance, and documentation
+openapi.yaml @SystonTigers
+AGENT.md @SystonTigers
+
+# Documentation bundle (current and future bundles)
+docs/** @SystonTigers
+docs-bundle/** @SystonTigers
+
+# Ensure API module changes receive review
+src/api_* @SystonTigers


### PR DESCRIPTION
## Summary
- add CODEOWNERS coverage for the OpenAPI spec and governance guide
- include documentation bundle globs so doc updates request review automatically
- ensure future `src/api_*` modules trigger CODEOWNERS review

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68db27d0d1b48329b6ffe1c9b7ee0c83