### PR TITLE
Fix manifest link to preserve Apps Script execution tokens

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,22 @@
     <meta name="apple-mobile-web-app-title" content="Club Console">
 
     <!-- PWA Manifest -->
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" id="pwa-manifest-link">
+    <script>
+        (function updateManifestLink() {
+            const manifestLink = document.querySelector('#pwa-manifest-link');
+            if (!manifestLink) {
+                return;
+            }
+
+            const { origin, pathname, search } = window.location;
+            const trimmedPath = pathname.replace(/\/+$/, '');
+            const baseUrl = trimmedPath ? `${origin}${trimmedPath}` : origin;
+            const manifestUrl = `${baseUrl}/manifest.json${search || ''}`;
+
+            manifestLink.setAttribute('href', manifestUrl);
+        })();
+    </script>
     <meta name="theme-color" content="#ff6600">
 
     <style>


### PR DESCRIPTION
## Summary
- compute the manifest link at runtime using the current origin, path, and query string so execution tokens remain in the request

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db3ab6d0908329830eae8377a4a33a