### PR TITLE
Fix service worker registration to retain Apps Script tokens

### DIFF
--- a/src/main.gs
+++ b/src/main.gs
@@ -113,12 +113,13 @@ function doGet(e) {
   try {
     // Simple routing without complex dependencies
     const path = (e && e.pathInfo) ? e.pathInfo : '';
-    const action = (e && e.parameter && e.parameter.action) ? e.parameter.action : '';
+    const params = (e && e.parameter) ? e.parameter : {};
+    const action = params && params.action ? params.action : '';
 
     // PUBLIC ROUTES (no authentication required)
 
     // Progressive Web App assets
-    const pwaResponse = handlePwaAssetRequest(path);
+    const pwaResponse = handlePwaAssetRequest(path, params);
     if (pwaResponse) {
       return pwaResponse;
     }

--- a/src/pwa-routes-svc.gs
+++ b/src/pwa-routes-svc.gs
@@ -7,15 +7,19 @@
 /**
  * Routes requests for PWA assets (manifest and service worker).
  * @param {string} path Path segment from the incoming request.
+ * @param {!Object<string, string>=} parameters Query parameters from the request.
  * @returns {ContentService.TextOutput|null} Response when handled.
  */
-function handlePwaAssetRequest(path) {
-  if (!path) {
+function handlePwaAssetRequest(path, parameters) {
+  const assetParam = parameters && parameters.asset ? String(parameters.asset) : '';
+  const selector = assetParam || path;
+  if (!selector) {
     return null;
   }
 
   try {
-    switch (String(path)) {
+    const normalized = String(selector).replace(/^\/+/, '');
+    switch (normalized) {
       case 'manifest.json':
         return createPwaManifestResponse_();
       case 'service-worker.js':

--- a/src/scripts.html
+++ b/src/scripts.html
@@ -52,7 +52,11 @@ function primePwaLifecycle() {
         return;
     }
 
-    const serviceWorkerUrl = new URL('service-worker.js', window.location.href).href;
+    const origin = window.location.origin;
+    const pathname = window.location.pathname;
+    const existingQuery = window.location.search || '';
+    const connector = existingQuery ? '&' : '?';
+    const serviceWorkerUrl = `${origin}${pathname}${existingQuery}${connector}asset=service-worker.js`;
 
     window.addEventListener('load', () => {
         navigator.serviceWorker.register(serviceWorkerUrl, { scope: './' })


### PR DESCRIPTION
## Summary
- derive the PWA service worker registration URL from the current origin, path, and query so Apps Script tokens are preserved
- update the PWA asset router to accept an `asset` query parameter when serving the service worker or manifest
- pass request parameters from `doGet` into the asset handler so query-based routing works

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68db3ab86cfc83299860b8dd0d9b17a8