### PR TITLE
Add direct YouTube publishing worker and nightly synthetics check

### DIFF
--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -1,0 +1,26 @@
+name: synthetics
+
+on:
+  schedule:
+    - cron: '22 3 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Health check
+        run: |
+          curl -fsS ${{ secrets.WORKER_BASE }}/healthz
+
+      - name: Enqueue sandbox post
+        run: |
+          curl -fsS -X POST ${{ secrets.WORKER_BASE }}/api/v1/post \
+            -H "authorization: Bearer ${{ secrets.SANDBOX_JWT }}" \
+            -H "content-type: application/json" \
+            -H "Idempotency-Key: syn-$(date +%s)" \
+            --data '{"tenant":"sandbox","template":"smoke","channels":["yt"],"data":{"msg":"hello"}}' \
+            -i
+
+      - name: Assert Queue drained (optional)
+        run: echo "If you expose /debug for admins, poll it here to ensure dequeue."

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "automation-script-workers",
       "version": "1.0.0",
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20240329.0",
+        "@cloudflare/workers-types": "^4.20240919.0",
         "esbuild": "^0.20.2",
-        "vitest": "^1.5.1"
+        "vitest": "^2.0.0"
       }
     },
     "node_modules/@cloudflare/workers-types": {
@@ -411,19 +411,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -739,13 +726,6 @@
         "win32"
       ]
     },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -754,126 +734,126 @@
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
-      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "1.6.1",
-        "@vitest/utils": "1.6.1",
-        "chai": "^4.3.10"
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
-      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "1.6.1",
-        "p-limit": "^5.0.0",
-        "pathe": "^1.1.1"
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
-      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "magic-string": "^0.30.5",
-        "pathe": "^1.1.1",
-        "pretty-format": "^29.7.0"
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
-      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyspy": "^2.2.0"
+        "tinyspy": "^3.0.2"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
-      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "diff-sequences": "^29.6.3",
-        "estree-walker": "^3.0.3",
-        "loupe": "^2.3.7",
-        "pretty-format": "^29.7.0"
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/cac": {
@@ -887,57 +867,30 @@
       }
     },
     "node_modules/chai": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
-      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.1.0"
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
       }
     },
     "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
       "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
+        "node": ">= 16"
       }
     },
     "node_modules/debug": {
@@ -959,27 +912,21 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/diff-sequences": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.20.2",
@@ -1030,28 +977,14 @@
         "@types/estree": "^1.0.0"
       }
     },
-    "node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
-      },
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fsevents": {
@@ -1069,92 +1002,12 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.17.0"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/local-pkg": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
-      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mlly": "^1.7.3",
-        "pkg-types": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
     },
     "node_modules/magic-string": {
       "version": "0.30.19",
@@ -1165,46 +1018,6 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
-    },
-    "node_modules/merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mlly": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
-      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "pathe": "^2.0.3",
-        "pkg-types": "^1.3.1",
-        "ufo": "^1.6.1"
-      }
-    },
-    "node_modules/mlly/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1232,77 +1045,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-limit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
-      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/pathe": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -1311,13 +1053,13 @@
       "license": "MIT"
     },
     "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -1326,25 +1068,6 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
-      }
-    },
-    "node_modules/pkg-types/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -1374,28 +1097,6 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
-    },
-    "node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.52.3",
@@ -1439,48 +1140,12 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1506,32 +1171,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/strip-literal": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
-      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -1539,10 +1178,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinypool": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
-      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1550,31 +1206,14 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
-      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ufo": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.20",
@@ -1637,16 +1276,16 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
-      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.3.4",
-        "pathe": "^1.1.1",
-        "picocolors": "^1.0.0",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
         "vite": "^5.0.0"
       },
       "bin": {
@@ -2090,32 +1729,32 @@
       }
     },
     "node_modules/vitest": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
-      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "1.6.1",
-        "@vitest/runner": "1.6.1",
-        "@vitest/snapshot": "1.6.1",
-        "@vitest/spy": "1.6.1",
-        "@vitest/utils": "1.6.1",
-        "acorn-walk": "^8.3.2",
-        "chai": "^4.3.10",
-        "debug": "^4.3.4",
-        "execa": "^8.0.1",
-        "local-pkg": "^0.5.0",
-        "magic-string": "^0.30.5",
-        "pathe": "^1.1.1",
-        "picocolors": "^1.0.0",
-        "std-env": "^3.5.0",
-        "strip-literal": "^2.0.0",
-        "tinybench": "^2.5.1",
-        "tinypool": "^0.8.3",
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
         "vite": "^5.0.0",
-        "vite-node": "1.6.1",
-        "why-is-node-running": "^2.2.2"
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
@@ -2129,8 +1768,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "1.6.1",
-        "@vitest/ui": "1.6.1",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -2155,22 +1794,6 @@
         }
       }
     },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2186,19 +1809,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yocto-queue": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20240329.0",
+    "@cloudflare/workers-types": "^4.20240919.0",
     "esbuild": "^0.20.2",
-    "vitest": "^1.5.1"
+    "vitest": "^2.0.0"
   }
 }

--- a/workers/__tests__/idempotency.spec.ts
+++ b/workers/__tests__/idempotency.spec.ts
@@ -1,0 +1,53 @@
+import type { KVNamespace } from '@cloudflare/workers-types';
+import { describe, expect, it } from 'vitest';
+import { ensureIdempotent } from '../runtime/idempotency';
+import type { AutomationEnv } from '../types';
+
+function createMockKV() {
+  const store = new Map<string, string>();
+  return {
+    async get(key: string) {
+      return store.get(key) ?? null;
+    },
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    }
+  } as unknown as KVNamespace;
+}
+
+describe('ensureIdempotent', () => {
+  it('stores and retrieves idempotent responses', async () => {
+    const env = {
+      KV_IDEMP: createMockKV(),
+      IDEMPOTENCY_TTL_SECONDS: '60'
+    } as unknown as AutomationEnv;
+
+    const payload = { tenant: 'clubA', template: 'fixture', data: { msg: 'hello' } };
+    const idem1 = await ensureIdempotent(env, 'clubA', payload);
+
+    expect(idem1.hit).toBe(false);
+
+    const response = { success: true, message: 'stored' };
+    await idem1.store(response);
+
+    const idem2 = await ensureIdempotent<typeof response>(env, 'clubA', payload);
+    expect(idem2.hit).toBe(true);
+    expect(idem2.response).toEqual(response);
+  });
+
+  it('uses explicit keys when provided', async () => {
+    const env = {
+      KV_IDEMP: createMockKV()
+    } as unknown as AutomationEnv;
+
+    const idem1 = await ensureIdempotent(env, 'clubB', { value: 1 }, 'custom-key');
+    expect(idem1.hit).toBe(false);
+    await idem1.store({ ok: true });
+
+    const idem2 = await ensureIdempotent(env, 'clubB', { value: 99 }, 'custom-key');
+    expect(idem2.hit).toBe(true);
+  });
+});

--- a/workers/__tests__/rate-limit.spec.ts
+++ b/workers/__tests__/rate-limit.spec.ts
@@ -1,0 +1,52 @@
+import type { DurableObjectStorage } from '@cloudflare/workers-types';
+import { describe, expect, it } from 'vitest';
+import { evaluateRateLimit } from '../runtime/rate-limit';
+
+function createMemoryStorage(): DurableObjectStorage {
+  const store = new Map<string, unknown>();
+  return {
+    async get<T>(key: string): Promise<T | undefined> {
+      return store.get(key) as T | undefined;
+    },
+    async put<T>(key: string, value: T): Promise<void> {
+      store.set(key, value);
+    },
+    async delete(key: string): Promise<void> {
+      store.delete(key);
+    },
+    async list() {
+      return { keys: [] } as unknown as Awaited<ReturnType<DurableObjectStorage['list']>>;
+    }
+  } as unknown as DurableObjectStorage;
+}
+
+describe('Rate limiter durable object logic', () => {
+  it('enforces limits within the same window', async () => {
+    const storage = createMemoryStorage();
+    const now = Date.now();
+
+    const first = await evaluateRateLimit(storage, 'tenantA', 2, 60, now);
+    expect(first.allowed).toBe(true);
+    expect(first.remaining).toBe(1);
+
+    const second = await evaluateRateLimit(storage, 'tenantA', 2, 60, now + 1000);
+    expect(second.allowed).toBe(true);
+    expect(second.remaining).toBe(0);
+
+    const third = await evaluateRateLimit(storage, 'tenantA', 2, 60, now + 2000);
+    expect(third.allowed).toBe(false);
+    expect(third.remaining).toBe(0);
+  });
+
+  it('resets after the window elapses', async () => {
+    const storage = createMemoryStorage();
+    const now = Date.now();
+
+    await evaluateRateLimit(storage, 'tenantB', 1, 5, now);
+    const blocked = await evaluateRateLimit(storage, 'tenantB', 1, 5, now + 1000);
+    expect(blocked.allowed).toBe(false);
+
+    const afterWindow = await evaluateRateLimit(storage, 'tenantB', 1, 5, now + 6000);
+    expect(afterWindow.allowed).toBe(true);
+  });
+});

--- a/workers/adapters/make.ts
+++ b/workers/adapters/make.ts
@@ -1,0 +1,38 @@
+import { fetchWithBackoff } from '../utils/http';
+import type { AutomationEnv, PublishResult, TenantRecord } from '../types';
+
+export async function publishViaMake(
+  env: Pick<AutomationEnv, 'MAKE_WEBHOOK_URL'>,
+  tenant: TenantRecord,
+  template: string,
+  data: Record<string, unknown>,
+  idempotencyKey?: string
+): Promise<PublishResult> {
+  if (!env.MAKE_WEBHOOK_URL) {
+    throw new Error('Make webhook not configured');
+  }
+
+  const payload = {
+    tenant: tenant.id,
+    template,
+    data,
+    flags: tenant.flags,
+    idempotencyKey
+  };
+
+  const response = await fetchWithBackoff(env.MAKE_WEBHOOK_URL, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...(idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : {})
+    },
+    body: JSON.stringify(payload)
+  });
+
+  return {
+    ok: true,
+    status: response.status,
+    forwarded: true,
+    data: response.data
+  } as PublishResult;
+}

--- a/workers/adapters/youtube.ts
+++ b/workers/adapters/youtube.ts
@@ -1,0 +1,161 @@
+import type { AutomationEnv, TenantRecord, YouTubeCredentials, YouTubePublishResult } from '../types';
+import { fetchWithBackoff } from '../utils/http';
+import { getYouTubeCredentials } from '../runtime/tokens';
+
+interface LiveBroadcastResponse {
+  id: string;
+}
+
+interface LiveStreamResponse {
+  id: string;
+}
+
+export async function publishYouTube(
+  env: AutomationEnv,
+  tenant: TenantRecord,
+  template: string,
+  data: Record<string, unknown>
+): Promise<YouTubePublishResult> {
+  const credentials = await getYouTubeCredentials(env, tenant.id);
+  if (!credentials) {
+    throw new Error('YouTube not configured for tenant');
+  }
+
+  const accessToken = await getGoogleAccessToken(credentials);
+  const privacy = normalizePrivacy(data.privacy);
+  const startTime = normalizeStartTime(data.start_iso);
+  const title = String(data.title || template || 'Match Live');
+  const description = String(data.description || 'Live stream');
+
+  const broadcast = await createLiveBroadcast(accessToken, {
+    title,
+    description,
+    scheduledStartTime: startTime,
+    privacyStatus: privacy
+  });
+  const stream = await createLiveStream(accessToken, { title: `${title} Stream` });
+  await bindBroadcast(accessToken, broadcast.id, stream.id);
+
+  return {
+    ok: true,
+    watch_url: `https://www.youtube.com/watch?v=${broadcast.id}`,
+    broadcast_id: broadcast.id,
+    stream_id: stream.id,
+    start_iso: startTime
+  };
+}
+
+function normalizePrivacy(input: unknown): 'public' | 'unlisted' | 'private' {
+  const allowed = ['public', 'unlisted', 'private'] as const;
+  const value = typeof input === 'string' ? input.toLowerCase() : 'unlisted';
+  return allowed.includes(value as (typeof allowed)[number])
+    ? (value as 'public' | 'unlisted' | 'private')
+    : 'unlisted';
+}
+
+function normalizeStartTime(input: unknown): string {
+  if (typeof input === 'string' && input) {
+    return input;
+  }
+  return new Date(Date.now() + 10 * 60 * 1000).toISOString();
+}
+
+async function getGoogleAccessToken(credentials: YouTubeCredentials): Promise<string> {
+  const params = new URLSearchParams({
+    client_id: credentials.client_id,
+    client_secret: credentials.client_secret,
+    refresh_token: credentials.refresh_token,
+    grant_type: 'refresh_token'
+  });
+
+  const result = await fetchWithBackoff<{ access_token?: string }>('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded'
+    },
+    body: params.toString()
+  });
+
+  if (!result.data?.access_token) {
+    throw new Error('OAuth token refresh failed');
+  }
+  return result.data.access_token;
+}
+
+async function createLiveBroadcast(
+  accessToken: string,
+  options: { title: string; description: string; scheduledStartTime: string; privacyStatus: 'public' | 'unlisted' | 'private' }
+): Promise<LiveBroadcastResponse> {
+  const payload = {
+    snippet: {
+      title: options.title,
+      description: options.description,
+      scheduledStartTime: options.scheduledStartTime
+    },
+    status: { privacyStatus: options.privacyStatus },
+    contentDetails: { enableAutoStart: true, enableAutoStop: true }
+  };
+
+  const result = await fetchWithBackoff<LiveBroadcastResponse>(
+    'https://www.googleapis.com/youtube/v3/liveBroadcasts?part=snippet,contentDetails,status',
+    {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    }
+  );
+
+  if (!result.data?.id) {
+    throw new Error('createLiveBroadcast failed');
+  }
+  return result.data;
+}
+
+async function createLiveStream(
+  accessToken: string,
+  options: { title: string }
+): Promise<LiveStreamResponse> {
+  const payload = {
+    snippet: { title: options.title },
+    cdn: { format: '1080p', ingestionType: 'rtmp' }
+  };
+
+  const result = await fetchWithBackoff<LiveStreamResponse>(
+    'https://www.googleapis.com/youtube/v3/liveStreams?part=snippet,cdn,status',
+    {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    }
+  );
+
+  if (!result.data?.id) {
+    throw new Error('createLiveStream failed');
+  }
+  return result.data;
+}
+
+async function bindBroadcast(accessToken: string, broadcastId: string, streamId: string): Promise<void> {
+  const url = new URL('https://www.googleapis.com/youtube/v3/liveBroadcasts/bind');
+  url.searchParams.set('id', broadcastId);
+  url.searchParams.set('part', 'id,contentDetails');
+  url.searchParams.set('streamId', streamId);
+
+  const response = await fetchWithBackoff(url.toString(), {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${accessToken}`
+    },
+    parseJson: false
+  });
+
+  if (!response.ok) {
+    throw new Error('bindBroadcast failed');
+  }
+}

--- a/workers/automation.ts
+++ b/workers/automation.ts
@@ -1,0 +1,261 @@
+import type { ExecutionContext, ExportedHandler } from '@cloudflare/workers-types';
+import { ensureIdempotent } from './runtime/idempotency';
+import { getTenant, saveTenant } from './runtime/tenant';
+import { storeYouTubeCredentials } from './runtime/tokens';
+import type { AutomationEnv, PublishJobBody, TenantRecord } from './types';
+
+interface JwtPayload {
+  sub?: string;
+  tenant?: string;
+  role?: string;
+  [key: string]: unknown;
+}
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' } as const;
+
+declare const Buffer: undefined | { from(input: string, encoding?: string): { toString(encoding: string): string } };
+
+const worker: ExportedHandler<AutomationEnv> = {
+  async fetch(request: Request, env: AutomationEnv, _ctx: ExecutionContext): Promise<Response> {
+    if (request.method === 'OPTIONS') {
+      return corsResponse(new Response(null, { status: 204 }));
+    }
+
+    const url = new URL(request.url);
+    const apiVersion = env.API_VERSION || 'v1';
+    const corsHeaders = buildCorsHeaders();
+
+    if (url.pathname === '/healthz') {
+      return jsonResponse({ ok: true, status: 'healthy' }, 200, corsHeaders);
+    }
+
+    if (url.pathname === `/api/${apiVersion}/post` && request.method === 'POST') {
+      return handlePost(request, env, corsHeaders);
+    }
+
+    if (url.pathname === `/api/${apiVersion}/admin/tenant/flags` && request.method === 'POST') {
+      return handleTenantFlags(request, env, corsHeaders);
+    }
+
+    if (url.pathname === `/api/${apiVersion}/admin/tenant/youtube-token` && request.method === 'POST') {
+      return handleTenantYouTubeToken(request, env, corsHeaders);
+    }
+
+    if (url.pathname === `/api/${apiVersion}/admin/tenant/force-make` && request.method === 'POST') {
+      return handleForceMake(request, env, corsHeaders);
+    }
+
+    return jsonResponse({ success: false, error: 'Not Found' }, 404, corsHeaders);
+  }
+};
+
+export default worker;
+
+async function handlePost(
+  request: Request,
+  env: AutomationEnv,
+  corsHeaders: Record<string, string>
+): Promise<Response> {
+  const payload = await authenticate(request, env, { requireAdmin: false });
+  if (!payload) {
+    return jsonResponse({ success: false, error: 'Unauthorized' }, 401, corsHeaders);
+  }
+
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body.tenant !== 'string' || !Array.isArray(body.channels) || typeof body.template !== 'string') {
+    return jsonResponse({ success: false, error: 'Invalid request body' }, 400, corsHeaders);
+  }
+
+  if (payload.tenant && payload.tenant !== body.tenant && payload.role !== 'admin') {
+    return jsonResponse({ success: false, error: 'Tenant mismatch' }, 403, corsHeaders);
+  }
+
+  const idempotencyKeyHeader = request.headers.get('Idempotency-Key') || undefined;
+  const idempotency = await ensureIdempotent<{ success: boolean; data: unknown }>(
+    env,
+    body.tenant,
+    { template: body.template, channels: body.channels, data: body.data },
+    idempotencyKeyHeader
+  );
+
+  if (idempotency.hit && idempotency.response) {
+    return jsonResponse(idempotency.response, 200, corsHeaders);
+  }
+
+  const job: PublishJobBody = {
+    tenant: body.tenant,
+    template: body.template,
+    channels: body.channels.map((channel: unknown) => String(channel)).filter(Boolean),
+    data: typeof body.data === 'object' && body.data ? body.data : {},
+    idempotencyKey: idempotency.key
+  };
+
+  await env.POST_QUEUE.send(job);
+
+  const responsePayload = {
+    success: true,
+    data: {
+      enqueued: true,
+      idempotencyKey: idempotency.key
+    }
+  };
+
+  await idempotency.store(responsePayload);
+
+  return jsonResponse(responsePayload, 202, corsHeaders);
+}
+
+async function handleTenantFlags(request: Request, env: AutomationEnv, corsHeaders: Record<string, string>): Promise<Response> {
+  const payload = await authenticate(request, env, { requireAdmin: true });
+  if (!payload) {
+    return jsonResponse({ success: false, error: 'Forbidden' }, 403, corsHeaders);
+  }
+
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body.tenant !== 'string' || typeof body.flags !== 'object') {
+    return jsonResponse({ success: false, error: 'tenant and flags required' }, 400, corsHeaders);
+  }
+
+  const existing = (await getTenant(env, body.tenant)) || {
+    id: body.tenant,
+    flags: {},
+    updatedAt: new Date().toISOString()
+  } as TenantRecord;
+  const mergedFlags = { ...existing.flags, ...(body.flags || {}) };
+  const updated = await saveTenant(env, body.tenant, { flags: mergedFlags });
+
+  return jsonResponse({ success: true, data: { tenant: body.tenant, flags: updated.flags } }, 200, corsHeaders);
+}
+
+async function handleTenantYouTubeToken(request: Request, env: AutomationEnv, corsHeaders: Record<string, string>): Promise<Response> {
+  const payload = await authenticate(request, env, { requireAdmin: true });
+  if (!payload) {
+    return jsonResponse({ success: false, error: 'Forbidden' }, 403, corsHeaders);
+  }
+
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body.tenant !== 'string' || typeof body.client_id !== 'string' || typeof body.client_secret !== 'string' || typeof body.refresh_token !== 'string') {
+    return jsonResponse({ success: false, error: 'tenant, client_id, client_secret, refresh_token required' }, 400, corsHeaders);
+  }
+
+  await storeYouTubeCredentials(env, body.tenant, {
+    client_id: body.client_id,
+    client_secret: body.client_secret,
+    refresh_token: body.refresh_token,
+    channel_id: typeof body.channel_id === 'string' ? body.channel_id : null
+  });
+
+  return jsonResponse({ success: true, data: { stored: true } }, 200, corsHeaders);
+}
+
+async function handleForceMake(request: Request, env: AutomationEnv, corsHeaders: Record<string, string>): Promise<Response> {
+  const payload = await authenticate(request, env, { requireAdmin: true });
+  if (!payload) {
+    return jsonResponse({ success: false, error: 'Forbidden' }, 403, corsHeaders);
+  }
+
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body.tenant !== 'string') {
+    return jsonResponse({ success: false, error: 'tenant required' }, 400, corsHeaders);
+  }
+
+  const existing = (await getTenant(env, body.tenant)) || {
+    id: body.tenant,
+    flags: {},
+    updatedAt: new Date().toISOString()
+  } as TenantRecord;
+  const updated = await saveTenant(env, body.tenant, {
+    flags: { ...existing.flags, use_make: true }
+  });
+
+  return jsonResponse({ success: true, data: { tenant: updated.id, flags: updated.flags } }, 200, corsHeaders);
+}
+
+async function authenticate(
+  request: Request,
+  env: AutomationEnv,
+  options: { requireAdmin: boolean }
+): Promise<JwtPayload | null> {
+  const authHeader = request.headers.get('authorization') || request.headers.get('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return null;
+  }
+  const token = authHeader.slice(7);
+  const secrets = [env.JWT_SECRET, env.ADMIN_JWT_SECRET].filter((value): value is string => Boolean(value));
+  for (const secret of secrets) {
+    try {
+      const payload = await verifyJwt(token, secret);
+      if (!options.requireAdmin || payload.role === 'admin') {
+        return payload;
+      }
+    } catch (error) {
+      continue;
+    }
+  }
+  return null;
+}
+
+async function verifyJwt(token: string, secret: string): Promise<JwtPayload> {
+  const [headerB64, payloadB64, signatureB64] = token.split('.');
+  if (!headerB64 || !payloadB64 || !signatureB64) {
+    throw new Error('Malformed token');
+  }
+
+  const encoder = new TextEncoder();
+  const data = encoder.encode(`${headerB64}.${payloadB64}`);
+  const signature = base64UrlToUint8Array(signatureB64);
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['verify']
+  );
+
+  const valid = await crypto.subtle.verify('HMAC', key, signature, data);
+  if (!valid) {
+    throw new Error('Invalid signature');
+  }
+
+  const payloadJson = JSON.parse(new TextDecoder().decode(base64UrlToUint8Array(payloadB64)));
+  return payloadJson as JwtPayload;
+}
+
+function base64UrlToUint8Array(base64Url: string): Uint8Array {
+  const padded = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const padLength = (4 - (padded.length % 4)) % 4;
+  const paddedBase64 = padded + '='.repeat(padLength);
+  const binary = typeof atob === 'function'
+    ? atob(paddedBase64)
+    : Buffer.from(paddedBase64, 'base64').toString('binary');
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function buildCorsHeaders(): Record<string, string> {
+  return {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'authorization,content-type,Idempotency-Key',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS'
+  };
+}
+
+function jsonResponse(body: unknown, status: number, corsHeaders: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...JSON_HEADERS,
+      ...corsHeaders
+    }
+  });
+}
+
+function corsResponse(response: Response): Response {
+  const corsHeaders = buildCorsHeaders();
+  const newHeaders = new Headers(response.headers);
+  Object.entries(corsHeaders).forEach(([key, value]) => newHeaders.set(key, value));
+  return new Response(response.body, { status: response.status, headers: newHeaders });
+}

--- a/workers/queue-consumer.ts
+++ b/workers/queue-consumer.ts
@@ -1,0 +1,96 @@
+import type { ExecutionContext, ExportedHandler, MessageBatch, QueueMessage } from '@cloudflare/workers-types';
+import { publishViaMake } from './adapters/make';
+import { publishYouTube } from './adapters/youtube';
+import { ensureIdempotent } from './runtime/idempotency';
+import { getTenant } from './runtime/tenant';
+import type { AutomationEnv, PublishJobBody, PublishResult, TenantRecord } from './types';
+import { fetchWithBackoff } from './utils/http';
+
+interface QueueMessageBody extends PublishJobBody {}
+
+const consumer: ExportedHandler<AutomationEnv> = {
+  async queue(batch: MessageBatch<QueueMessageBody>, env: AutomationEnv, ctx: ExecutionContext): Promise<void> {
+    for (const message of batch.messages) {
+      await handleMessage(message, env, ctx);
+    }
+  }
+};
+
+export default consumer;
+
+async function handleMessage(message: QueueMessage<QueueMessageBody>, env: AutomationEnv, ctx: ExecutionContext): Promise<void> {
+  const job = message.body;
+  try {
+    const tenant = await getTenant(env, job.tenant);
+    if (!tenant) {
+      console.warn('Queue message skipped – unknown tenant', { tenant: job.tenant });
+      message.ack();
+      return;
+    }
+
+    const idempotency = job.idempotencyKey
+      ? await ensureIdempotent(env, job.tenant, { job: job.idempotencyKey }, job.idempotencyKey)
+      : null;
+
+    if (idempotency?.hit) {
+      console.log('Idempotency hit for job', { key: job.idempotencyKey });
+      message.ack();
+      return;
+    }
+
+    const results: Record<string, PublishResult> = {};
+
+    for (const channel of job.channels) {
+      try {
+        results[channel] = await publishForChannel(env, tenant, channel, job);
+      } catch (error) {
+        console.error('Channel publish failed', { tenant: tenant.id, channel, error: error instanceof Error ? error.message : error });
+        if (!tenant.flags?.use_make && env.MAKE_WEBHOOK_URL) {
+          results[channel] = await publishViaMake(env, tenant, job.template, { ...job.data, fallback_error: String(error) }, job.idempotencyKey);
+          ctx.waitUntil(notifyFailure(env, tenant, channel, error));
+        } else {
+          message.retry();
+          return;
+        }
+      }
+    }
+
+    message.ack();
+    await idempotency?.store({ success: true, results });
+  } catch (error) {
+    console.error('Queue processing error', error);
+    message.retry();
+  }
+}
+
+async function publishForChannel(
+  env: AutomationEnv,
+  tenant: TenantRecord,
+  channel: string,
+  job: PublishJobBody
+): Promise<PublishResult> {
+  if (tenant.flags?.use_make || channel !== 'yt' || !tenant.flags?.direct_yt) {
+    return publishViaMake(env, tenant, job.template, job.data, job.idempotencyKey);
+  }
+
+  return publishYouTube(env, tenant, job.template, job.data);
+}
+
+async function notifyFailure(env: AutomationEnv, tenant: TenantRecord, channel: string, error: unknown): Promise<void> {
+  if (!env.ALERT_WEBHOOK_URL) {
+    return;
+  }
+  try {
+    await fetchWithBackoff(env.ALERT_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        tenant: tenant.id,
+        channel,
+        message: error instanceof Error ? error.message : String(error)
+      })
+    }, 2);
+  } catch (alertError) {
+    console.warn('Failed to send alert notification', alertError);
+  }
+}

--- a/workers/runtime/idempotency.ts
+++ b/workers/runtime/idempotency.ts
@@ -1,0 +1,82 @@
+import type { AutomationEnv } from '../types';
+
+declare const Buffer: undefined | { from(input: Uint8Array | string, encoding?: string): { toString(encoding: string): string } };
+
+const DEFAULT_TTL_SECONDS = 60 * 60 * 24;
+const IDEMPOTENCY_PREFIX = 'idem:';
+
+export interface IdempotentResult<T> {
+  key: string;
+  hit: boolean;
+  response?: T;
+  store(response: T): Promise<void>;
+}
+
+interface StoredPayload<T> {
+  storedAt: string;
+  response: T;
+}
+
+const encoder = new TextEncoder();
+
+function toBase64Url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const binary = Array.from(bytes)
+    .map(byte => String.fromCharCode(byte))
+    .join('');
+  const base64 = typeof btoa === 'function'
+    ? btoa(binary)
+    : Buffer.from(bytes).toString('base64');
+  return base64.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+async function digestSha256(input: string): Promise<string> {
+  const bytes = encoder.encode(input);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', bytes);
+  return toBase64Url(hashBuffer);
+}
+
+export async function ensureIdempotent<T = unknown>(
+  env: Pick<AutomationEnv, 'KV_IDEMP' | 'IDEMPOTENCY_TTL_SECONDS'>,
+  tenantId: string,
+  payload: unknown,
+  explicitKey?: string
+): Promise<IdempotentResult<T>> {
+  const baseKey = explicitKey || `${tenantId}:${await digestSha256(JSON.stringify(payload ?? {}))}`;
+  const kvKey = IDEMPOTENCY_PREFIX + baseKey;
+  const ttl = Number.parseInt(env.IDEMPOTENCY_TTL_SECONDS || '', 10);
+  const expirationTtl = Number.isFinite(ttl) && ttl > 0 ? ttl : DEFAULT_TTL_SECONDS;
+
+  const storedRaw = await env.KV_IDEMP.get(kvKey);
+  if (storedRaw) {
+    try {
+      const parsed = JSON.parse(storedRaw) as StoredPayload<T>;
+      return {
+        key: baseKey,
+        hit: true,
+        response: parsed.response,
+        store: async () => {}
+      };
+    } catch (error) {
+      console.warn('Failed to parse stored idempotent payload', error);
+    }
+  }
+
+  return {
+    key: baseKey,
+    hit: false,
+    store: async (response: T) => {
+      const payloadToStore: StoredPayload<T> = {
+        storedAt: new Date().toISOString(),
+        response
+      };
+      await env.KV_IDEMP.put(kvKey, JSON.stringify(payloadToStore), {
+        expirationTtl
+      });
+    }
+  };
+}
+
+export function clearIdempotentKey(env: Pick<AutomationEnv, 'KV_IDEMP'>, key: string): Promise<void> {
+  return env.KV_IDEMP.delete(IDEMPOTENCY_PREFIX + key);
+}

--- a/workers/runtime/rate-limit.ts
+++ b/workers/runtime/rate-limit.ts
@@ -1,0 +1,87 @@
+import type { DurableObjectState, DurableObjectStorage } from '@cloudflare/workers-types';
+import type { AutomationEnv } from '../types';
+
+const DEFAULT_LIMIT = 30;
+const DEFAULT_WINDOW_SECONDS = 60;
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  resetSeconds: number;
+}
+
+interface StoredCounter {
+  count: number;
+  resetAt: number;
+}
+
+export async function evaluateRateLimit(
+  storage: DurableObjectStorage,
+  key: string,
+  limit: number,
+  windowSeconds: number,
+  now: number
+): Promise<RateLimitResult> {
+  const windowMs = windowSeconds * 1000;
+  const record = (await storage.get<StoredCounter>(key)) || { count: 0, resetAt: now + windowMs };
+
+  if (!record.resetAt || record.resetAt <= now) {
+    record.count = 0;
+    record.resetAt = now + windowMs;
+  }
+
+  record.count += 1;
+  const allowed = record.count <= limit;
+  const remaining = allowed ? limit - record.count : 0;
+
+  await storage.put(key, record);
+
+  return {
+    allowed,
+    remaining,
+    resetSeconds: Math.max(0, Math.ceil((record.resetAt - now) / 1000))
+  };
+}
+
+export class RateLimiterDurableObject {
+  private defaultLimit: number;
+  private defaultWindow: number;
+
+  constructor(private state: DurableObjectState, env: AutomationEnv) {
+    const parsedLimit = Number.parseInt(env.RATE_LIMIT_DEFAULT_LIMIT || '', 10);
+    const parsedWindow = Number.parseInt(env.RATE_LIMIT_DEFAULT_WINDOW || '', 10);
+    this.defaultLimit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : DEFAULT_LIMIT;
+    this.defaultWindow = Number.isFinite(parsedWindow) && parsedWindow > 0 ? parsedWindow : DEFAULT_WINDOW_SECONDS;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+      return new Response('Method Not Allowed', {
+        status: 405,
+        headers: { 'Allow': 'POST' }
+      });
+    }
+
+    const body = await request.json().catch(() => null);
+    if (!body || typeof body.key !== 'string') {
+      return jsonResponse({ success: false, error: 'Invalid rate limit request' }, 400);
+    }
+
+    const limit = typeof body.limit === 'number' && body.limit > 0 ? body.limit : this.defaultLimit;
+    const windowSeconds = typeof body.windowSeconds === 'number' && body.windowSeconds > 0
+      ? body.windowSeconds
+      : this.defaultWindow;
+
+    const now = typeof body.now === 'number' && Number.isFinite(body.now) ? body.now : Date.now();
+    const result = await evaluateRateLimit(this.state.storage, body.key, limit, windowSeconds, now);
+
+    return jsonResponse({ success: true, result });
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}

--- a/workers/runtime/tenant.ts
+++ b/workers/runtime/tenant.ts
@@ -1,0 +1,43 @@
+import type { AutomationEnv, TenantFlags, TenantRecord } from '../types';
+
+const TENANT_PREFIX = 'tenant:';
+
+export async function getTenant(env: Pick<AutomationEnv, 'KV_TENANT_FLAGS'>, tenantId: string): Promise<TenantRecord | null> {
+  const raw = await env.KV_TENANT_FLAGS.get(TENANT_PREFIX + tenantId);
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as TenantRecord;
+    if (!parsed.flags) {
+      parsed.flags = {};
+    }
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to parse tenant record', { tenantId, error });
+    return null;
+  }
+}
+
+export async function saveTenant(
+  env: Pick<AutomationEnv, 'KV_TENANT_FLAGS'>,
+  tenantId: string,
+  update: Partial<TenantRecord>
+): Promise<TenantRecord> {
+  const existing = await getTenant(env, tenantId);
+  const merged: TenantRecord = {
+    ...existing,
+    ...update,
+    id: tenantId,
+    flags: { ...existing?.flags, ...(update.flags || {}) },
+    updatedAt: new Date().toISOString()
+  };
+  await env.KV_TENANT_FLAGS.put(TENANT_PREFIX + tenantId, JSON.stringify(merged));
+  return merged;
+}
+
+export function applyFlagUpdate(record: TenantRecord, flags: TenantFlags): TenantRecord {
+  record.flags = { ...record.flags, ...flags };
+  record.updatedAt = new Date().toISOString();
+  return record;
+}

--- a/workers/runtime/tokens.ts
+++ b/workers/runtime/tokens.ts
@@ -1,0 +1,31 @@
+import type { AutomationEnv, YouTubeCredentials } from '../types';
+
+const YOUTUBE_PREFIX = 'yt:';
+
+export async function storeYouTubeCredentials(
+  env: Pick<AutomationEnv, 'KV_YOUTUBE_TOKENS'>,
+  tenantId: string,
+  credentials: YouTubeCredentials
+): Promise<void> {
+  await env.KV_YOUTUBE_TOKENS.put(YOUTUBE_PREFIX + tenantId, JSON.stringify({
+    ...credentials,
+    storedAt: new Date().toISOString()
+  }));
+}
+
+export async function getYouTubeCredentials(
+  env: Pick<AutomationEnv, 'KV_YOUTUBE_TOKENS'>,
+  tenantId: string
+): Promise<YouTubeCredentials | null> {
+  const raw = await env.KV_YOUTUBE_TOKENS.get(YOUTUBE_PREFIX + tenantId);
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as YouTubeCredentials;
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to parse YouTube credentials', { tenantId, error });
+    return null;
+  }
+}

--- a/workers/types.ts
+++ b/workers/types.ts
@@ -1,0 +1,62 @@
+import type { KVNamespace, MessageSendOptions, Queue } from '@cloudflare/workers-types';
+
+export interface TenantFlags {
+  use_make?: boolean;
+  direct_yt?: boolean;
+  [key: string]: unknown;
+}
+
+export interface TenantRecord {
+  id: string;
+  flags: TenantFlags;
+  updatedAt: string;
+  [key: string]: unknown;
+}
+
+export interface PublishJobBody {
+  tenant: string;
+  template: string;
+  channels: string[];
+  data: Record<string, unknown>;
+  idempotencyKey?: string;
+}
+
+export interface AutomationEnv {
+  API_VERSION?: string;
+  JWT_SECRET?: string;
+  ADMIN_JWT_SECRET?: string;
+  MAKE_WEBHOOK_URL?: string;
+  IDEMPOTENCY_TTL_SECONDS?: string;
+  RATE_LIMIT_DEFAULT_LIMIT?: string;
+  RATE_LIMIT_DEFAULT_WINDOW?: string;
+  POST_QUEUE: Queue<PublishJobBody>;
+  KV_TENANT_FLAGS: KVNamespace;
+  KV_YOUTUBE_TOKENS: KVNamespace;
+  KV_IDEMP: KVNamespace;
+  ALERT_WEBHOOK_URL?: string;
+}
+
+export type QueueSendOptions = MessageSendOptions | undefined;
+
+export interface TenantContext {
+  record: TenantRecord;
+}
+
+export interface PublishResult {
+  ok: boolean;
+  [key: string]: unknown;
+}
+
+export interface YouTubeCredentials {
+  client_id: string;
+  client_secret: string;
+  refresh_token: string;
+  channel_id?: string | null;
+}
+
+export interface YouTubePublishResult extends PublishResult {
+  watch_url: string;
+  broadcast_id: string;
+  stream_id: string;
+  start_iso: string;
+}

--- a/workers/utils/http.ts
+++ b/workers/utils/http.ts
@@ -1,0 +1,61 @@
+const DEFAULT_ATTEMPTS = 4;
+const DEFAULT_BASE_DELAY = 400;
+
+export interface FetchOptions extends RequestInit {
+  parseJson?: boolean;
+}
+
+export interface FetchJsonResult<T = unknown> {
+  status: number;
+  ok: boolean;
+  data: T | null;
+  response: Response;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function fetchWithBackoff<T = unknown>(
+  url: string,
+  init: FetchOptions = {},
+  attempts = DEFAULT_ATTEMPTS,
+  baseDelay = DEFAULT_BASE_DELAY
+): Promise<FetchJsonResult<T>> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      const response = await fetch(url, init);
+      const { status } = response;
+      if (status >= 200 && status < 300) {
+        const data = init.parseJson === false ? null : await safeParseJson<T>(response);
+        return { status, ok: true, data, response };
+      }
+
+      lastError = new Error(`HTTP ${status}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (attempt < attempts - 1) {
+      const delay = baseDelay * Math.pow(2, attempt);
+      await sleep(delay);
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error('HTTP request failed');
+}
+
+async function safeParseJson<T>(response: Response): Promise<T | null> {
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch (error) {
+    console.warn('Failed to parse JSON response', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add Worker API endpoints for posting jobs plus admin flag and YouTube token management with KV-backed idempotency
- implement YouTube publisher, Make fallback queue consumer, reusable runtime utilities, and tenant credential storage
- add nightly synthetics workflow, vitest coverage for idempotency/rate limiting, and update worker testing dependencies

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db3d029a68832986a85a67fec1da12