### PR TITLE
Add QA curl smoke scripts for promo code flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,23 @@ clasp push
 
 ---
 
+## 🧪 QA Smoke Tests
+
+Run the backend promo code smoke checks locally before handing off to QA:
+
+```bash
+export API_BASE_URL="https://worker.example.com"   # e.g. https://syston.app
+export ADMIN_JWT="$(pbpaste)"                      # admin bearer token
+./qa/curl-admin.sh                                  # create → list → deactivate promo code
+
+export API_BASE_URL="https://worker.example.com"
+./qa/curl-signup-with-promo.sh                      # validates signup flow upgrades plan
+```
+
+Both scripts require `curl` and `jq`; override defaults (tenant, promo code, etc.) with the env vars documented inline in each script.
+
+---
+
 ## 📂 Repository Structure
 
 ```

--- a/qa/curl-admin.sh
+++ b/qa/curl-admin.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+BASE_URL="${1:-${API_BASE_URL:-}}"
+if [[ -z "${BASE_URL}" ]]; then
+  echo "Usage: API_BASE_URL=https://worker.example.com ADMIN_JWT=... $0" >&2
+  exit 1
+fi
+
+if [[ -z "${ADMIN_JWT:-}" ]]; then
+  echo "ADMIN_JWT must be set in the environment" >&2
+  exit 1
+fi
+
+PROMO_CODE="${PROMO_CODE:-SYSTON-PRO-2025}"
+TENANT_ID="${PROMO_TENANT_ID:-syston}"
+PLAN_ID="${PROMO_PLAN_ID:-pro}" # Expected plan slug in provisioning service
+
+function admin_curl() {
+  local method="$1"
+  local path="$2"
+  local data="${3:-}"
+  local url="${BASE_URL%/}${path}"
+
+  if [[ -n "${data}" ]]; then
+    curl --fail-with-body -sS -X "${method}" "${url}" \
+      -H "authorization: Bearer ${ADMIN_JWT}" \
+      -H 'content-type: application/json' \
+      -d "${data}"
+  else
+    curl --fail-with-body -sS -X "${method}" "${url}" \
+      -H "authorization: Bearer ${ADMIN_JWT}" \
+      -H 'content-type: application/json'
+  fi
+}
+
+echo "[1/3] Creating promo code ${PROMO_CODE} for tenant ${TENANT_ID}"
+create_payload=$(jq -n \
+  --arg code "${PROMO_CODE}" \
+  --arg tenant "${TENANT_ID}" \
+  --arg plan "${PLAN_ID}" \
+  '{
+    code: $code,
+    tenantId: $tenant,
+    kind: "plan_upgrade",
+    plan: $plan,
+    metadata: {
+      maxRedemptions: 250,
+      expiresAt: "2025-12-31T23:59:59Z"
+    }
+  }')
+create_resp=$(admin_curl POST "/api/v1/admin/promo-codes" "${create_payload}")
+echo "${create_resp}" | jq '.'
+
+echo "[2/3] Listing promo codes"
+list_resp=$(admin_curl GET "/api/v1/admin/promo-codes")
+echo "${list_resp}" | jq '.'
+echo "${list_resp}" | jq -e --arg code "${PROMO_CODE}" '.data.codes[] | select(.code == $code) | .active == true' >/dev/null
+
+echo "[3/3] Deactivating promo code ${PROMO_CODE}"
+deactivate_resp=$(admin_curl POST "/api/v1/admin/promo-codes/${PROMO_CODE}/deactivate")
+echo "${deactivate_resp}" | jq '.'
+
+echo "Promo code smoke run completed"

--- a/qa/curl-signup-with-promo.sh
+++ b/qa/curl-signup-with-promo.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+BASE_URL="${1:-${API_BASE_URL:-}}"
+if [[ -z "${BASE_URL}" ]]; then
+  echo "Usage: API_BASE_URL=https://worker.example.com $0" >&2
+  exit 1
+fi
+
+SIGNUP_PATH="${SIGNUP_PATH:-/api/v1/auth/signup}"
+PROMO_CODE="${PROMO_CODE:-SYSTON-PRO-2025}"
+TENANT_ID="${PROMO_TENANT_ID:-syston}"
+EMAIL="${PROMO_EMAIL:-qa+promo-$(date +%s)@example.com}"
+PASSWORD="${PROMO_PASSWORD:-SystonPromo123!}"
+EXPECTED_PLAN="${EXPECTED_PLAN:-PRO}"
+EXPECTED_FLAG="${EXPECTED_FLAG:-pro_console}"
+
+# Allow callers to inject additional JSON via SIGNUP_EXTRA (must be valid JSON or empty)
+EXTRA_JSON="${SIGNUP_EXTRA:-{}}"
+if ! extra_obj=$(jq -n "${EXTRA_JSON}"); then
+  echo "SIGNUP_EXTRA must be valid JSON" >&2
+  exit 1
+fi
+
+payload=$(jq -n \
+  --arg email "${EMAIL}" \
+  --arg password "${PASSWORD}" \
+  --arg promo "${PROMO_CODE}" \
+  --arg tenant "${TENANT_ID}" \
+  --argjson extra "${extra_obj}" \
+  '{
+    email: $email,
+    password: $password,
+    tenantId: $tenant,
+    promoCode: $promo
+  } + $extra')
+
+url="${BASE_URL%/}${SIGNUP_PATH}"
+
+echo "Submitting signup for ${EMAIL} with promo ${PROMO_CODE}"
+response=$(curl --fail-with-body -sS -X POST "${url}" \
+  -H 'content-type: application/json' \
+  -d "${payload}")
+
+echo "Response:" >&2
+echo "${response}" | jq '.' >&2
+
+plan_ok=$(echo "${response}" | jq -e --arg plan "${EXPECTED_PLAN}" '
+  (
+    [
+      (.data.plan?),
+      (.data.user?.plan?),
+      (.data.account?.plan?),
+      (.plan?),
+      (.user?.plan?)
+    ]
+    | map(select(type == "string") | ascii_upcase)
+    | any(. == ($plan | ascii_upcase))
+  )
+') || {
+  echo "Expected plan ${EXPECTED_PLAN} not present in response" >&2
+  exit 1
+}
+
+flag_ok=$(echo "${response}" | jq -e --arg flag "${EXPECTED_FLAG}" '
+  (
+    [
+      (.data.flags?),
+      (.data.user?.flags?),
+      (.data.account?.flags?),
+      (.flags?),
+      (.user?.flags?)
+    ]
+    | map(select(type == "object"))
+    | map(.[$flag])
+    | map(select(. != null))
+    | any((. == true) or (. == "true"))
+  )
+') || {
+  echo "Expected flag ${EXPECTED_FLAG} not present in response" >&2
+  exit 1
+}
+
+echo "Signup promo smoke passed for ${EMAIL}"


### PR DESCRIPTION
## Summary
- add curl-based admin smoke script to create, list, and deactivate promo codes
- add signup smoke script that validates promo upgrades and flags
- document how to run the new QA smoke checks in the main README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1b436b2f883299cc8e75f7e43934d