### PR TITLE
Add highlights export workflow for video automation

### DIFF
--- a/src/video-clips.gs
+++ b/src/video-clips.gs
@@ -1074,6 +1074,342 @@ function getAllVideoClips() {
 }
 
 /**
+ * Export highlight events to Drive JSON for a match
+ * @param {string} matchId - Match identifier
+ * @returns {{ok:boolean, path:string, count:number, fileId?:string, url?:string, events?:Array<Object>, reason?:string}}
+ */
+function exportEventsForHighlights(matchId) {
+  const highlightsLogger = logger.scope('VideoHighlights');
+  highlightsLogger.enterFunction('exportEventsForHighlights', { matchId });
+
+  // @testHook('video.export.events.start')
+
+  const normalizedMatchId = (matchId || '').toString().trim();
+  if (!normalizedMatchId) {
+    highlightsLogger.warn('Match ID is required for highlights export');
+    highlightsLogger.exitFunction('exportEventsForHighlights', { success: false, reason: 'missing_match_id' });
+    return { ok: false, path: '', count: 0, reason: 'missing_match_id' };
+  }
+
+  try {
+    const spreadsheet = getSheet();
+    const sheetNames = Array.from(new Set([
+      getConfigValue('SHEETS.TAB_NAMES.LIVE_MATCH_UPDATES', ''),
+      getConfigValue('SHEETS.TAB_NAMES.PLAYER_EVENTS', '')
+    ].filter(Boolean)));
+
+    const events = [];
+    const seen = new Set();
+
+    sheetNames.forEach(sheetName => {
+      const sheet = spreadsheet.getSheetByName(sheetName);
+      if (!sheet) {
+        highlightsLogger.warn('Sheet not found for highlights export', { sheetName });
+        return;
+      }
+
+      const lastRow = sheet.getLastRow();
+      const lastColumn = sheet.getLastColumn();
+
+      if (lastRow < 2 || lastColumn === 0) {
+        return;
+      }
+
+      const headers = sheet.getRange(1, 1, 1, lastColumn).getValues()[0]
+        .map(header => (header || '').toString().trim());
+      const headerMap = headers.reduce((acc, header, index) => {
+        const key = header.toLowerCase();
+        if (!acc[key]) {
+          acc[key] = index;
+        }
+        return acc;
+      }, {});
+
+      const matchColumnIndex = getFirstAvailableIndex_(headerMap, ['match id', 'matchid', 'fixture id', 'fixture', 'game id']);
+      if (typeof matchColumnIndex !== 'number') {
+        highlightsLogger.warn('Skipping sheet without match column for highlights export', { sheetName });
+        return;
+      }
+
+      const batchSize = 250;
+      for (let startRow = 2; startRow <= lastRow; startRow += batchSize) {
+        const rowCount = Math.min(batchSize, lastRow - startRow + 1);
+        const rows = sheet.getRange(startRow, 1, rowCount, lastColumn).getValues();
+
+        rows.forEach(row => {
+          const rowMatchId = (row[matchColumnIndex] || '').toString().trim();
+          if (rowMatchId !== normalizedMatchId) {
+            return;
+          }
+
+          const minute = extractValueFromRow_(row, headerMap, ['minute']);
+          const type = extractValueFromRow_(row, headerMap, ['event type', 'event', 'type']);
+          const player = extractValueFromRow_(row, headerMap, ['player', 'player name']);
+          const assist = extractValueFromRow_(row, headerMap, ['assist', 'assisted by']);
+          const team = extractValueFromRow_(row, headerMap, ['team', 'side', 'squad', 'opponent', 'opposition']);
+          const notes = extractValueFromRow_(row, headerMap, ['notes', 'details', 'description']);
+
+          if (!minute && !type && !player) {
+            return;
+          }
+
+          const eventRecord = {
+            minute: minute,
+            type: type,
+            player: player,
+            assist: assist,
+            team: team,
+            notes: notes
+          };
+
+          const dedupeKey = [
+            minute || '',
+            type || '',
+            player || '',
+            assist || '',
+            team || '',
+            notes || ''
+          ].map(value => value.toString().toLowerCase()).join('||');
+
+          if (!seen.has(dedupeKey)) {
+            seen.add(dedupeKey);
+            events.push(eventRecord);
+          }
+        });
+      }
+    });
+
+    if (events.length === 0) {
+      highlightsLogger.warn('No events found for highlights export', { matchId: normalizedMatchId });
+      highlightsLogger.exitFunction('exportEventsForHighlights', { success: false, reason: 'no_events' });
+      return { ok: false, path: '', count: 0, reason: 'no_events' };
+    }
+
+    const fileName = `events_${normalizedMatchId}.json`;
+    const jsonPayload = JSON.stringify({
+      matchId: normalizedMatchId,
+      generatedAt: new Date().toISOString(),
+      events: events
+    });
+
+    const folderId = getConfigValue('VIDEO.HIGHLIGHTS_FOLDER_ID', null) || getConfigValue('VIDEO.DRIVE_FOLDER_ID', null);
+    let folder = null;
+    if (folderId) {
+      try {
+        folder = DriveApp.getFolderById(folderId);
+      } catch (folderError) {
+        highlightsLogger.warn('Unable to access configured highlights folder, using root', {
+          error: folderError instanceof Error ? folderError.message : String(folderError)
+        });
+        folder = null;
+      }
+    }
+
+    let file = null;
+    const fileIterator = folder
+      ? folder.getFilesByName(fileName)
+      : DriveApp.getFilesByName(fileName);
+
+    if (fileIterator && fileIterator.hasNext()) {
+      file = fileIterator.next();
+      file.setContent(jsonPayload);
+    } else {
+      file = folder
+        ? folder.createFile(fileName, jsonPayload)
+        : DriveApp.createFile(fileName, jsonPayload);
+    }
+
+    const eventsUrl = `https://drive.google.com/uc?export=download&id=${file.getId()}`;
+    const path = folder ? `${folder.getName()}/${fileName}` : fileName;
+
+    const result = {
+      ok: true,
+      path: path,
+      count: events.length,
+      fileId: file.getId(),
+      url: eventsUrl,
+      events: events
+    };
+
+    highlightsLogger.exitFunction('exportEventsForHighlights', {
+      success: true,
+      count: events.length,
+      fileId: file.getId()
+    });
+
+    // @testHook('video.export.events.end')
+
+    return result;
+
+  } catch (error) {
+    highlightsLogger.error('Failed to export highlights events', {
+      error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+      matchId: normalizedMatchId
+    });
+    highlightsLogger.exitFunction('exportEventsForHighlights', { success: false, reason: 'error' });
+    return { ok: false, path: '', count: 0, reason: 'error', error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
+ * Trigger highlights bot webhook with exported events
+ * @param {string} matchId - Match identifier
+ * @param {string} videoUrl - Processed video URL
+ * @param {string} [webhookUrl] - Optional override webhook URL
+ * @returns {{ok:boolean, dispatched?:boolean, status?:number, reason?:string, events?:Object}}
+ */
+function triggerHighlightsBot(matchId, videoUrl, webhookUrl) {
+  const highlightsLogger = logger.scope('VideoHighlights');
+  highlightsLogger.enterFunction('triggerHighlightsBot', {
+    matchId,
+    hasVideoUrl: !!videoUrl,
+    hasWebhookOverride: !!webhookUrl
+  });
+
+  const normalizedMatchId = (matchId || '').toString().trim();
+  const normalizedVideoUrl = (videoUrl || '').toString().trim();
+
+  if (!normalizedMatchId) {
+    highlightsLogger.warn('Cannot trigger highlights bot without match ID');
+    highlightsLogger.exitFunction('triggerHighlightsBot', { success: false, reason: 'missing_match_id' });
+    return { ok: false, reason: 'missing_match_id' };
+  }
+
+  if (!normalizedVideoUrl) {
+    highlightsLogger.warn('Cannot trigger highlights bot without video URL');
+    highlightsLogger.exitFunction('triggerHighlightsBot', { success: false, reason: 'missing_video_url' });
+    return { ok: false, reason: 'missing_video_url' };
+  }
+
+  try {
+    const exportResult = exportEventsForHighlights(normalizedMatchId);
+    if (!exportResult.ok) {
+      highlightsLogger.warn('Highlights export did not return events', {
+        matchId: normalizedMatchId,
+        reason: exportResult.reason
+      });
+      highlightsLogger.exitFunction('triggerHighlightsBot', { success: false, reason: exportResult.reason || 'export_failed' });
+      return { ok: false, reason: exportResult.reason || 'export_failed' };
+    }
+
+    const scriptProperties = PropertiesService.getScriptProperties();
+    const configuredWebhook = (scriptProperties.getProperty('HIGHLIGHTS_WEBHOOK_URL') || '').trim();
+    const resolvedWebhook = (webhookUrl || '').trim() || configuredWebhook;
+
+    if (!resolvedWebhook) {
+      highlightsLogger.warn('No highlights webhook configured');
+      highlightsLogger.exitFunction('triggerHighlightsBot', { success: true, dispatched: false, reason: 'no_webhook' });
+      return { ok: true, dispatched: false, reason: 'no_webhook', events: exportResult };
+    }
+
+    const requestId = typeof StringUtils !== 'undefined' && StringUtils && typeof StringUtils.generateId === 'function'
+      ? StringUtils.generateId('req')
+      : Utilities.getUuid();
+
+    const payload = {
+      matchId: normalizedMatchId,
+      eventsUrl: exportResult.url || exportResult.path,
+      videoUrl: normalizedVideoUrl
+    };
+
+    const requestOptions = {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Request-Id': requestId,
+        'X-Request-Source': 'video_highlights_exporter'
+      },
+      maxRetries: 4,
+      retryDelay: 1000,
+      muteHttpExceptions: true,
+      timeout: 20000
+    };
+
+    // @testHook('video.trigger.webhook.pre')
+    const response = httpPost(resolvedWebhook, payload, requestOptions);
+    // @testHook('video.trigger.webhook.post')
+
+    const success = response && response.success && response.statusCode >= 200 && response.statusCode < 300;
+
+    if (!success) {
+      highlightsLogger.error('Highlights webhook failed', {
+        statusCode: response ? response.statusCode : null,
+        error: response ? response.error : 'unknown',
+        matchId: normalizedMatchId
+      });
+      highlightsLogger.exitFunction('triggerHighlightsBot', {
+        success: false,
+        dispatched: false,
+        reason: 'webhook_failed',
+        statusCode: response ? response.statusCode : null
+      });
+      return {
+        ok: false,
+        dispatched: false,
+        reason: 'webhook_failed',
+        status: response ? response.statusCode : null,
+        events: exportResult
+      };
+    }
+
+    highlightsLogger.exitFunction('triggerHighlightsBot', {
+      success: true,
+      dispatched: true,
+      statusCode: response.statusCode
+    });
+
+    return {
+      ok: true,
+      dispatched: true,
+      status: response.statusCode,
+      events: exportResult
+    };
+
+  } catch (error) {
+    highlightsLogger.error('Failed to trigger highlights webhook', {
+      error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+      matchId: normalizedMatchId
+    });
+    highlightsLogger.exitFunction('triggerHighlightsBot', { success: false, reason: 'error' });
+    return { ok: false, reason: 'error', error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
+ * Find the first available header index from candidates
+ * @param {Object} headerMap - Map of header name to column index
+ * @param {Array<string>} candidates - Candidate header names (lowercase)
+ * @returns {number|undefined}
+ */
+function getFirstAvailableIndex_(headerMap, candidates) {
+  for (let i = 0; i < candidates.length; i += 1) {
+    const key = candidates[i];
+    if (Object.prototype.hasOwnProperty.call(headerMap, key)) {
+      return headerMap[key];
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Extract value from row using header map
+ * @param {Array<*>} row - Row data
+ * @param {Object} headerMap - Header to index map
+ * @param {Array<string>} keys - Candidate header names
+ * @returns {string}
+ */
+function extractValueFromRow_(row, headerMap, keys) {
+  const index = getFirstAvailableIndex_(headerMap, keys);
+  if (typeof index !== 'number') {
+    return '';
+  }
+  const value = row[index];
+  if (value === null || typeof value === 'undefined') {
+    return '';
+  }
+  return value instanceof Date ? value.toISOString() : value.toString().trim();
+}
+
+/**
  * Initialize video clips system
  * @returns {Object} Initialization result
  */


### PR DESCRIPTION
## Summary
- add `exportEventsForHighlights` to build deduplicated highlights JSON exports to Drive and `triggerHighlightsBot` to notify downstream automation
- expose a "Export highlights JSON" spreadsheet menu action to run the export plus webhook trigger with user prompts
- cover no-event, single-event, and duplicate-event scenarios with new edge-case tests and Drive stubs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1b3dc61bc8329a94a51c4efe551fd