### PR TITLE
Add QA result placeholders for 2025-10-05 runs

### DIFF
--- a/qa/cors-test-results-2025-10-05.md
+++ b/qa/cors-test-results-2025-10-05.md
@@ -1,0 +1,14 @@
+# CORS QA — 2025-10-05
+
+## Summary
+- ❌ `qa/curl-cors.sh` was not executed.
+
+## Details
+- The script requires the real staging/dev base URL and authentication headers that are distributed only through the secure CI secrets store.
+- Those secrets are intentionally unavailable in this sandbox environment to prevent accidental leakage.
+- Running the script without valid credentials would produce misleading failures, so it was skipped.
+
+## Next Steps
+1. Run `bash qa/curl-cors.sh` from a workstation with access to the staging environment credentials.
+2. Capture the full terminal output (including HTTP status codes and timing data) and store it in this file.
+3. Verify that the recorded output demonstrates the expected CORS headers for all tested endpoints.

--- a/qa/edge-case-results-2025-10-05.md
+++ b/qa/edge-case-results-2025-10-05.md
@@ -1,0 +1,14 @@
+# Edge Case Test Harness — 2025-10-05
+
+## Summary
+- ❌ Unable to execute functions from `src/edge-case-tests.gs`.
+
+## Details
+- These tests are Apps Script functions that depend on runtime services (SpreadsheetApp, UrlFetchApp) tied to the production staging environment.
+- Running them requires an authenticated Apps Script session with seeded sheet data, which is not available here.
+- Without proper context the functions would throw runtime errors, so execution was skipped.
+
+## Next Steps
+1. Run each function in `src/edge-case-tests.gs` from the Apps Script QA project (e.g., via the built-in test runner).
+2. Export the execution transcripts, including console logs and assertion results, and paste them into this document.
+3. Record any failures with links to Drive artifacts or screenshots as evidence for reviewers.

--- a/qa/highlights-test-results-2025-10-05.md
+++ b/qa/highlights-test-results-2025-10-05.md
@@ -1,0 +1,14 @@
+# Highlights Export QA — 2025-10-05
+
+## Summary
+- ❌ Highlights export automation not executed.
+
+## Details
+- The export job calls third-party APIs and writes to Drive folders that require customer-specific credentials; these secrets are not provisioned in this sandbox.
+- Without the proper Script Properties and OAuth grants, the job cannot be executed safely.
+- No console output is available because the job was never started.
+
+## Next Steps
+1. Re-run the highlights export from the Apps Script QA project with the correct tenant bindings.
+2. Save the Apps Script execution log (including timestamps and item counts) and update this artifact.
+3. Verify that the exported files appear in the staging Drive folder before closing the QA ticket.

--- a/qa/historical-import-results-2025-10-05.md
+++ b/qa/historical-import-results-2025-10-05.md
@@ -1,0 +1,14 @@
+# Historical Import QA — 2025-10-05
+
+## Summary
+- ❌ Historical import flow not run.
+
+## Details
+- The historical import requires access to production-like Google Drive folders and tenant spreadsheets that are not accessible from this container.
+- Triggering the import without verified sandbox data risks modifying customer records, so it was intentionally skipped.
+- No execution transcript was generated as the flow was not started.
+
+## Next Steps
+1. Execute the historical import via the sanctioned QA Apps Script deployment with staging copies of the sheets.
+2. Export the execution log (timestamps, row counts, error messages) and paste it into this file.
+3. Confirm that the sheet audit tabs reflect the imported ranges before marking the QA checklist complete.

--- a/qa/selftest-results-2025-10-05.md
+++ b/qa/selftest-results-2025-10-05.md
@@ -1,0 +1,14 @@
+# Make Integration Self-Test Results — 2025-10-05
+
+## Summary
+- ❌ Unable to execute `runMakeIntegrationSelfTests()` in this environment.
+
+## Details
+- Attempted to locate executable entrypoint within repository, but the flow is defined in Apps Script (`src/qa.selftest.gs`) and requires execution inside the Google Apps Script runtime with access to staging/dev spreadsheets and Make.com webhooks.
+- The current automation container does not have connectivity to the Apps Script project or authentication credentials (OAuth token / `clasp` environment) necessary to invoke the function remotely.
+- Running the flow without the required secrets would fail and risk exposing production data, so the execution was skipped as a safety measure.
+
+## Next Steps
+1. Run `runMakeIntegrationSelfTests()` from the Apps Script editor or via the internal QA deployment that has the appropriate Script Properties configured.
+2. Capture the execution transcript from the Apps Script execution log and attach it here.
+3. Re-run once staging credentials are available in the automated test environment.


### PR DESCRIPTION
## Summary
- add dated QA result artifacts documenting that the required staging/dev flows could not be executed in this environment
- outline the dependencies and next steps needed to capture real execution logs for each QA flow

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e1cbe33be48329840463da597c8df2