### PR TITLE
Add historical import and video clip unit tests

### DIFF
--- a/qa/unit-test-results.md
+++ b/qa/unit-test-results.md
@@ -1,0 +1,64 @@
+# Unit Test Results
+
+- **Run date:** Sun Oct 5 01:45:40 UTC 2025 (UTC)
+- **Execution method:** Node VM harness evaluating Apps Script sources and unit suites (`runHistoricalImportUnitTests`, `runVideoClipsUnitTests`).
+
+## Historical Import Suite
+
+```
+{
+  "name": "Historical Import CSV Processing",
+  "tests": [
+    {
+      "name": "parses varied CSV rows and generates events",
+      "status": "PASS",
+      "details": "Parsed 2 records, generated 5 events"
+    },
+    {
+      "name": "detects duplicate matches by match key hash",
+      "status": "PASS",
+      "details": "Duplicate rows detected: 1"
+    },
+    {
+      "name": "produces stable match hash keys",
+      "status": "PASS",
+      "details": "Normalized match key: 2024-08-20#our club#rivals fc"
+    }
+  ],
+  "passed": 3,
+  "failed": 0,
+  "total": 3,
+  "status": "PASS"
+}
+```
+
+## Video Clips Suite
+
+```
+{
+  "name": "Video Clips Automation",
+  "tests": [
+    {
+      "name": "creates goal clip metadata with buffers applied",
+      "status": "PASS",
+      "details": "Clip clip_1 saved with duration 40s"
+    },
+    {
+      "name": "ensures player folders resolve with Drive context",
+      "status": "PASS",
+      "details": "Folder path resolved as Video Root/AlexMorgan"
+    },
+    {
+      "name": "builds YouTube payload from stored metadata",
+      "status": "PASS",
+      "details": "YouTube payload ready with title \"Alex Morgan Goal vs Rivals\""
+    }
+  ],
+  "passed": 3,
+  "failed": 0,
+  "total": 3,
+  "status": "PASS"
+}
+```
+
+- **Follow-up actions:** None required. All targeted suites passed successfully.

--- a/src/test-execution.gs
+++ b/src/test-execution.gs
@@ -205,6 +205,60 @@ function runComprehensiveSystemTest() {
     testResults.totalTests++;
   }
 
+  // Test 7: Historical Import Unit Tests
+  console.log('Test 7: Historical Import Unit Tests');
+  try {
+    const historicalSuite = runHistoricalImportUnitTests();
+    historicalSuite.tests.forEach(function(test) {
+      testResults.results.push({
+        test: 'Historical Import - ' + test.name,
+        status: test.status,
+        details: test.details
+      });
+      if (test.status === 'PASS') {
+        testResults.passedTests++;
+      } else {
+        testResults.failedTests++;
+      }
+      testResults.totalTests++;
+    });
+  } catch (error) {
+    testResults.results.push({
+      test: 'Historical Import Suite',
+      status: 'ERROR',
+      details: error.toString()
+    });
+    testResults.failedTests++;
+    testResults.totalTests++;
+  }
+
+  // Test 8: Video Clips Unit Tests
+  console.log('Test 8: Video Clips Unit Tests');
+  try {
+    const videoSuite = runVideoClipsUnitTests();
+    videoSuite.tests.forEach(function(test) {
+      testResults.results.push({
+        test: 'Video Clips - ' + test.name,
+        status: test.status,
+        details: test.details
+      });
+      if (test.status === 'PASS') {
+        testResults.passedTests++;
+      } else {
+        testResults.failedTests++;
+      }
+      testResults.totalTests++;
+    });
+  } catch (error) {
+    testResults.results.push({
+      test: 'Video Clips Suite',
+      status: 'ERROR',
+      details: error.toString()
+    });
+    testResults.failedTests++;
+    testResults.totalTests++;
+  }
+
   // Calculate final results
   testResults.passRate = Math.round((testResults.passedTests / testResults.totalTests) * 100);
 

--- a/test/historical-import.test.gs
+++ b/test/historical-import.test.gs
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for historical CSV import utilities.
+ * These tests target CSV parsing edge cases, duplicate detection,
+ * and the stability of the match hashing logic used for dedupe.
+ */
+function runHistoricalImportUnitTests() {
+  const suite = createHistoricalSuite_('Historical Import CSV Processing');
+
+  addHistoricalTest_(suite, 'parses varied CSV rows and generates events', function() {
+    const csvText = [
+      'Date,Home Team,Away Team,Comp,Venue,HS,AS,Scorers,Cards',
+      "12/09/2024,Our Club,Rivals FC,League,Home,2,1,Player One 45'; Player Two 78',Player Three 60' yellow",
+      ',,,,,,,,',
+      "19-09-2024,Rivals FC,Our Club,Cup,Away,1,3,Player Four 22',Player Five 70' red"
+    ].join('\n');
+
+    const deps = createHistoricalTestDeps_();
+    const result = parseHistoricalCsv_(csvText, deps);
+
+    expectHistoricalEqual_(result.records.length, 2, 'Should parse two non-empty records');
+    expectHistoricalEqual_(result.duplicates, 0, 'No duplicates expected in edge case CSV');
+
+    const seasons = Object.keys(result.recordsBySeason);
+    expectHistorical_(seasons.includes('2024/25'), 'Parsed season should include 2024/25');
+
+    const firstRecord = result.records[0];
+    expectHistoricalEqual_(firstRecord.events.length, 3, 'First record should create three events');
+
+    const totalEvents = result.records.reduce(function(total, record) {
+      return total + record.events.length;
+    }, 0);
+    expectHistoricalEqual_(result.projectedEventCount, totalEvents, 'Projected event count should match actual events');
+
+    return 'Parsed 2 records, generated ' + totalEvents + ' events';
+  });
+
+  addHistoricalTest_(suite, 'detects duplicate matches by match key hash', function() {
+    const csvText = [
+      'Date,HomeTeam,AwayTeam,Competition,Venue,HS,AS,Scorers,Cards',
+      "01/08/2024,Our Club,Rivals,Cup,Home,3,0,Player One 12',Player Two 30' yellow",
+      "01/08/2024,Our Club,Rivals,Cup,Home,3,0,Player One 12',Player Two 30' yellow",
+      "08/08/2024,Rivals,Our Club,Cup,Away,1,2,Player Three 70',"
+    ].join('\n');
+
+    const deps = createHistoricalTestDeps_();
+    const result = parseHistoricalCsv_(csvText, deps);
+
+    expectHistoricalEqual_(result.records.length, 2, 'Duplicate row should be skipped');
+    expectHistoricalEqual_(result.duplicates, 1, 'Duplicate counter should be incremented');
+
+    return 'Duplicate rows detected: ' + result.duplicates;
+  });
+
+  addHistoricalTest_(suite, 'produces stable match hash keys', function() {
+    const deps = createHistoricalTestDeps_();
+    const utilities = deps.utilities;
+    const referenceDate = new Date(Date.UTC(2024, 7, 20));
+
+    const keyA = buildMatchKey_(referenceDate, 'Our Club', 'Rivals FC', utilities);
+    const keyB = buildMatchKey_(new Date(Date.UTC(2024, 7, 20)), '  our   club ', 'rivals fc ', utilities);
+
+    expectHistoricalEqual_(keyA, keyB, 'Match keys should be normalized across casing and whitespace');
+
+    return 'Normalized match key: ' + keyA;
+  });
+
+  return finalizeHistoricalSuite_(suite);
+}
+
+function createHistoricalTestDeps_() {
+  return {
+    utilities: {
+      parseCsv: function(csvText) {
+        return csvText.split(/\r?\n/).map(function(line) {
+          return line.split(',').map(function(cell) {
+            return cell.replace(/^"|"$/g, '').trim();
+          });
+        });
+      },
+      formatDate: function(date) {
+        var year = date.getUTCFullYear();
+        var month = String(date.getUTCMonth() + 1).padStart(2, '0');
+        var day = String(date.getUTCDate()).padStart(2, '0');
+        return year + '-' + month + '-' + day;
+      }
+    },
+    stringUtils: {
+      cleanPlayerName: function(name) {
+        return String(name || '').trim();
+      }
+    },
+    clubNameNormalized: 'our club',
+    options: {}
+  };
+}
+
+function createHistoricalSuite_(name) {
+  return {
+    name: name,
+    tests: [],
+    passed: 0,
+    failed: 0
+  };
+}
+
+function addHistoricalTest_(suite, name, fn) {
+  try {
+    var details = fn();
+    suite.tests.push({ name: name, status: 'PASS', details: details || '' });
+    suite.passed += 1;
+  } catch (error) {
+    suite.tests.push({
+      name: name,
+      status: 'FAIL',
+      details: error instanceof Error ? error.message : String(error)
+    });
+    suite.failed += 1;
+  }
+}
+
+function expectHistorical_(condition, message) {
+  if (!condition) {
+    throw new Error(message || 'Expected condition to be truthy');
+  }
+}
+
+function expectHistoricalEqual_(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error((message || 'Values should be equal') + ' (expected ' + expected + ', got ' + actual + ')');
+  }
+}
+
+function finalizeHistoricalSuite_(suite) {
+  suite.total = suite.passed + suite.failed;
+  suite.status = suite.failed === 0 ? 'PASS' : 'FAIL';
+  return suite;
+}

--- a/test/video-clips.test.gs
+++ b/test/video-clips.test.gs
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for the video clips manager covering clip metadata creation,
+ * Drive folder orchestration, and YouTube payload validation.
+ */
+function runVideoClipsUnitTests() {
+  const suite = createVideoSuite_('Video Clips Automation');
+
+  addVideoTest_(suite, 'creates goal clip metadata with buffers applied', function() {
+    const manager = new VideoClipsManager();
+
+    const saved = [];
+    const processingCalls = [];
+    manager.saveClipMetadata = function(metadata) {
+      saved.push(metadata);
+      return { success: true };
+    };
+    manager.ensurePlayerFolder = function(player) {
+      return { success: true, folder_id: 'player-folder-1', folder_path: 'Video Root/' + player };
+    };
+    manager.ensureMatchFolder = function(matchId) {
+      return { success: true, folder_id: 'match-folder-1', folder_path: 'Match Highlights/' + matchId };
+    };
+    manager.requestCloudConvertProcessing = function(metadata) {
+      processingCalls.push(metadata);
+      return { success: true, job_id: 'make-123' };
+    };
+    manager.getMatchInfo = function() {
+      return { date: '12/09/2024', opponent: 'Rivals FC', venue: 'Stadium', competition: 'League' };
+    };
+
+    const result = manager.createGoalClip('67', 'Alex Morgan', 'Sam Kerr', 'Rivals FC', 'match-001');
+
+    expectVideo_(result.success, 'Goal clip creation should succeed');
+    const clipMetadata = result.clip_metadata;
+    expectVideo_(clipMetadata, 'Clip metadata should be returned');
+    expectVideoEqual_(clipMetadata.event_type, 'goal', 'Event type should be goal');
+
+    const buffers = getConfigValue('VIDEO.CLIP_BUFFERS.GOAL', { preSeconds: 0, postSeconds: 0 });
+    const preBuffer = Number(buffers.preSeconds) || 0;
+    const postBuffer = Number(buffers.postSeconds) || 0;
+    const expectedStart = Math.max(0, (67 * 60) - preBuffer);
+    const defaultDuration = getConfigValue('VIDEO.DEFAULT_CLIP_DURATION', 30);
+    const expectedDuration = Math.max(preBuffer + postBuffer, defaultDuration);
+
+    expectVideoEqual_(clipMetadata.start_time_seconds, expectedStart, 'Pre-buffer should be applied to start time');
+    expectVideoEqual_(clipMetadata.duration_seconds, expectedDuration, 'Duration should respect configured minimum');
+    expectVideo_(clipMetadata.player_folder_id === 'player-folder-1', 'Player folder id should be attached');
+    expectVideo_(clipMetadata.match_folder_id === 'match-folder-1', 'Match folder id should be attached');
+    expectVideoEqual_(processingCalls.length, 1, 'Processing should be requested once');
+    expectVideo_(processingCalls[0] === clipMetadata, 'Processing payload should reuse clip metadata reference');
+
+    return 'Clip ' + clipMetadata.clip_id + ' saved with duration ' + clipMetadata.duration_seconds + 's';
+  });
+
+  addVideoTest_(suite, 'ensures player folders resolve with Drive context', function() {
+    const manager = new VideoClipsManager();
+    const originalGetFolderById = DriveApp.getFolderById;
+    const originalGetOrCreate = manager.getOrCreatePlayerFolder;
+    let requestedPlayer = '';
+
+    DriveApp.getFolderById = function(id) {
+      return {
+        getName: function() { return 'Video Root'; }
+      };
+    };
+
+    manager.getOrCreatePlayerFolder = function(player) {
+      requestedPlayer = player;
+      return {
+        getId: function() { return 'player-folder-42'; },
+        getName: function() { return 'AlexMorgan'; }
+      };
+    };
+
+    const result = manager.ensurePlayerFolder('Alex Morgan');
+
+    DriveApp.getFolderById = originalGetFolderById;
+    manager.getOrCreatePlayerFolder = originalGetOrCreate;
+
+    expectVideo_(result.success, 'ensurePlayerFolder should succeed when Drive is configured');
+    expectVideoEqual_(requestedPlayer, 'Alex Morgan', 'Player name should be forwarded to helper');
+    expectVideoEqual_(result.folder_id, 'player-folder-42', 'Folder id should match helper result');
+    expectVideoEqual_(result.folder_path, 'Video Root/AlexMorgan', 'Folder path should include Drive root and player folder');
+
+    return 'Folder path resolved as ' + result.folder_path;
+  });
+
+  addVideoTest_(suite, 'builds YouTube payload from stored metadata', function() {
+    const manager = new VideoClipsManager();
+    let capturedParams = null;
+    let updatedClip = null;
+
+    manager.getClipMetadata = function() {
+      return {
+        title: 'Alex Morgan Goal vs Rivals',
+        description: 'Match winner',
+        tags: ['Our Club', 'Goal']
+      };
+    };
+    manager.executeYouTubeUpload = function(filePath, params) {
+      capturedParams = params;
+      return { success: true, youtube_url: 'https://youtu.be/demo', video_id: 'demo123' };
+    };
+    manager.updateClipWithYouTubeInfo = function(clipId, url, videoId) {
+      updatedClip = { clipId: clipId, url: url, videoId: videoId };
+    };
+
+    const result = manager.uploadToYouTube('clip-123', '/tmp/video.mp4');
+
+    expectVideo_(result.success, 'YouTube upload should report success');
+    expectVideo_(capturedParams !== null, 'Upload parameters should be captured');
+    expectVideoEqual_(capturedParams.title, 'Alex Morgan Goal vs Rivals', 'Title should match clip metadata');
+    expectVideoEqual_(capturedParams.privacy, 'unlisted', 'Privacy should respect configuration');
+    expectVideo_(Array.isArray(capturedParams.tags) && capturedParams.tags.length === 2, 'Tags should be forwarded');
+    expectVideo_(updatedClip && updatedClip.clipId === 'clip-123', 'Clip metadata should be updated with YouTube info');
+
+    return 'YouTube payload ready with title "' + capturedParams.title + '"';
+  });
+
+  return finalizeVideoSuite_(suite);
+}
+
+function createVideoSuite_(name) {
+  return {
+    name: name,
+    tests: [],
+    passed: 0,
+    failed: 0
+  };
+}
+
+function addVideoTest_(suite, name, fn) {
+  try {
+    var details = fn();
+    suite.tests.push({ name: name, status: 'PASS', details: details || '' });
+    suite.passed += 1;
+  } catch (error) {
+    suite.tests.push({
+      name: name,
+      status: 'FAIL',
+      details: error instanceof Error ? error.message : String(error)
+    });
+    suite.failed += 1;
+  }
+}
+
+function expectVideo_(condition, message) {
+  if (!condition) {
+    throw new Error(message || 'Expected condition to be truthy');
+  }
+}
+
+function expectVideoEqual_(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error((message || 'Values should be equal') + ' (expected ' + expected + ', got ' + actual + ')');
+  }
+}
+
+function finalizeVideoSuite_(suite) {
+  suite.total = suite.passed + suite.failed;
+  suite.status = suite.failed === 0 ? 'PASS' : 'FAIL';
+  return suite;
+}


### PR DESCRIPTION
## Summary
- add Apps Script unit tests for historical CSV parsing edge cases, duplicate detection, and match hash stability
- add video clip automation unit tests covering metadata generation, Drive folder resolution, and YouTube payload assembly
- wire both suites into runComprehensiveSystemTest and capture the execution output in qa/unit-test-results.md

## Testing
- node - <<'NODE' … (inline VM harness to execute runHistoricalImportUnitTests and runVideoClipsUnitTests; see qa/unit-test-results.md for full output)


------
https://chatgpt.com/codex/tasks/task_e_68e1cbe5e92883299dc1a270915bd6bf