### PR TITLE
Document blocked QA runs due to missing staging access

### DIFF
--- a/qa/cors-test-results-2025-10-05.md
+++ b/qa/cors-test-results-2025-10-05.md
@@ -1,14 +1,14 @@
 # CORS QA — 2025-10-05
 
 ## Summary
-- ❌ `qa/curl-cors.sh` was not executed.
+- ❌ `qa/curl-cors.sh` could not be run from the container because staging base URLs and auth headers are only available via secure CI secrets.
 
-## Details
-- The script requires the real staging/dev base URL and authentication headers that are distributed only through the secure CI secrets store.
-- Those secrets are intentionally unavailable in this sandbox environment to prevent accidental leakage.
-- Running the script without valid credentials would produce misleading failures, so it was skipped.
+## Attempt Log — 2025-10-05 02:05 UTC
+- Inspected `qa/curl-cors.sh` and confirmed it expects environment variables that reference the staging tenant API endpoint.
+- Verified no credentials are provisioned in this sandbox, so executing the script would result in unauthorized responses and leak placeholder URLs into the evidence log.
+- Skipped execution to avoid producing misleading failures or exposing redacted endpoints.
 
-## Next Steps
-1. Run `bash qa/curl-cors.sh` from a workstation with access to the staging environment credentials.
-2. Capture the full terminal output (including HTTP status codes and timing data) and store it in this file.
-3. Verify that the recorded output demonstrates the expected CORS headers for all tested endpoints.
+## Required Manual Steps
+1. Execute `bash qa/curl-cors.sh` from a workstation that has the staging environment secrets configured.
+2. Capture the full terminal output (status codes, headers, latency) and replace this section with the raw log.
+3. Attach any relevant webhook responses so reviewers can confirm Access-Control headers across endpoints.

--- a/qa/edge-case-results-2025-10-05.md
+++ b/qa/edge-case-results-2025-10-05.md
@@ -1,14 +1,14 @@
 # Edge Case Test Harness — 2025-10-05
 
 ## Summary
-- ❌ Unable to execute functions from `src/edge-case-tests.gs`.
+- ❌ Functions in `src/edge-case-tests.gs` were not executed because the Apps Script runtime with staging Sheet data is unavailable from this container.
 
-## Details
-- These tests are Apps Script functions that depend on runtime services (SpreadsheetApp, UrlFetchApp) tied to the production staging environment.
-- Running them requires an authenticated Apps Script session with seeded sheet data, which is not available here.
-- Without proper context the functions would throw runtime errors, so execution was skipped.
+## Attempt Log — 2025-10-05 02:05 UTC
+- Reviewed the edge-case test functions and confirmed they require SpreadsheetApp access to seeded QA sheets plus UrlFetch calls to staging webhooks.
+- Verified no Google authentication context exists here (`ScriptApp`, `SpreadsheetApp`, `UrlFetchApp` are unavailable), so the tests cannot run headlessly.
+- Skipped execution to avoid runtime errors and misleading artifacts.
 
-## Next Steps
-1. Run each function in `src/edge-case-tests.gs` from the Apps Script QA project (e.g., via the built-in test runner).
-2. Export the execution transcripts, including console logs and assertion results, and paste them into this document.
-3. Record any failures with links to Drive artifacts or screenshots as evidence for reviewers.
+## Required Manual Steps
+1. Run each function in `src/edge-case-tests.gs` through the staging Apps Script project or its QA test runner.
+2. Export the execution transcripts (logs, assertions, error output) and paste the raw data into this file.
+3. Capture any Drive or webhook evidence referenced by the tests so reviewers can validate edge-case handling.

--- a/qa/highlights-test-results-2025-10-05.md
+++ b/qa/highlights-test-results-2025-10-05.md
@@ -1,14 +1,14 @@
 # Highlights Export QA — 2025-10-05
 
 ## Summary
-- ❌ Highlights export automation not executed.
+- ❌ `exportEventsForHighlights` / `triggerHighlightsBot` were not executed because required staging credentials and webhook URLs are unavailable in this environment.
 
-## Details
-- The export job calls third-party APIs and writes to Drive folders that require customer-specific credentials; these secrets are not provisioned in this sandbox.
-- Without the proper Script Properties and OAuth grants, the job cannot be executed safely.
-- No console output is available because the job was never started.
+## Attempt Log — 2025-10-05 02:05 UTC
+- Confirmed the flow reads Script Properties for staging webhook endpoints and Drive destinations that are not present locally.
+- Noted that running without the correct OAuth grants would cause UrlFetch calls to fail and could ping production webhooks.
+- Execution skipped to avoid unauthorized API calls and to keep evidence aligned with secure environments.
 
-## Next Steps
-1. Re-run the highlights export from the Apps Script QA project with the correct tenant bindings.
-2. Save the Apps Script execution log (including timestamps and item counts) and update this artifact.
-3. Verify that the exported files appear in the staging Drive folder before closing the QA ticket.
+## Required Manual Steps
+1. Run `exportEventsForHighlights` followed by `triggerHighlightsBot` inside the staging Apps Script deployment.
+2. Capture the full Apps Script log output (timestamps, counts, webhook responses) and paste it verbatim here.
+3. Include confirmation of created highlight files or bot acknowledgements so reviewers can verify success.

--- a/qa/historical-import-results-2025-10-05.md
+++ b/qa/historical-import-results-2025-10-05.md
@@ -1,14 +1,14 @@
 # Historical Import QA — 2025-10-05
 
 ## Summary
-- ❌ Historical import flow not run.
+- ❌ Historical CSV import was not executed because the staging Drive folder and seeded spreadsheets are inaccessible from this container.
 
-## Details
-- The historical import requires access to production-like Google Drive folders and tenant spreadsheets that are not accessible from this container.
-- Triggering the import without verified sandbox data risks modifying customer records, so it was intentionally skipped.
-- No execution transcript was generated as the flow was not started.
+## Attempt Log — 2025-10-05 02:05 UTC
+- Reviewed the historical import instructions and confirmed they require Drive file IDs stored in Script Properties for the staging tenant.
+- Checked the local environment and verified no Script Properties or OAuth grants are available, so Drive access would fail with authorization errors.
+- Skipped execution to prevent accidental writes to production sheets or partial imports with missing credentials.
 
-## Next Steps
-1. Execute the historical import via the sanctioned QA Apps Script deployment with staging copies of the sheets.
-2. Export the execution log (timestamps, row counts, error messages) and paste it into this file.
-3. Confirm that the sheet audit tabs reflect the imported ranges before marking the QA checklist complete.
+## Required Manual Steps
+1. Launch the historical import flow from the staging Apps Script project that has the correct Drive bindings.
+2. Record the before/after row counts and attach the raw Apps Script execution transcript in this file.
+3. Include any webhook or error responses so reviewers can verify the data load completed successfully.

--- a/qa/selftest-results-2025-10-05.md
+++ b/qa/selftest-results-2025-10-05.md
@@ -1,14 +1,14 @@
 # Make Integration Self-Test Results — 2025-10-05
 
 ## Summary
-- ❌ Unable to execute `runMakeIntegrationSelfTests()` in this environment.
+- ❌ `runMakeIntegrationSelfTests()` could not be executed from the container because the staging Apps Script project is inaccessible without the required OAuth credentials and Script Properties.
 
-## Details
-- Attempted to locate executable entrypoint within repository, but the flow is defined in Apps Script (`src/qa.selftest.gs`) and requires execution inside the Google Apps Script runtime with access to staging/dev spreadsheets and Make.com webhooks.
-- The current automation container does not have connectivity to the Apps Script project or authentication credentials (OAuth token / `clasp` environment) necessary to invoke the function remotely.
-- Running the flow without the required secrets would fail and risk exposing production data, so the execution was skipped as a safety measure.
+## Attempt Log — 2025-10-05 02:05 UTC
+- Confirmed the function definition lives in `src/qa.selftest.gs`, which must be invoked inside Google Apps Script with the staging tenant configuration loaded.
+- Verified this workspace has no `~/.clasprc.json` or Script Properties for the staging tenant, so remote execution would fail authentication.
+- Execution was skipped to avoid triggering calls against production webhooks without the proper sandbox bindings.
 
-## Next Steps
-1. Run `runMakeIntegrationSelfTests()` from the Apps Script editor or via the internal QA deployment that has the appropriate Script Properties configured.
-2. Capture the execution transcript from the Apps Script execution log and attach it here.
-3. Re-run once staging credentials are available in the automated test environment.
+## Required Manual Steps
+1. Run `runMakeIntegrationSelfTests()` within the staging Apps Script deployment that already has the correct Script Properties.
+2. Download the Apps Script execution transcript (including timestamps and assertion results) and paste the raw log output into this file.
+3. Re-run after ensuring the Make.com webhook credentials are valid so reviewers can see the real payload counts.


### PR DESCRIPTION
## Summary
- note that Phase 1 QA flows could not be executed from the container due to missing staging credentials
- record the time and reason for skipping each flow in the dated evidence files

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e1d21f05cc8329be26ea212951b43c