### PR TITLE
Remove legacy filePushOrder manifest directive

### DIFF
--- a/src/appsscript.json
+++ b/src/appsscript.json
@@ -29,13 +29,5 @@
   },
   "executionApi": {
     "access": "DOMAIN"
-  },
-  "filePushOrder": [
-    "video/clips-manager",
-    "video/drive-organization",
-    "video/graphics-generator",
-    "video/youtube-integration",
-    "video/processing-queue",
-    "video-clips"
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
- remove the deprecated filePushOrder section from the Apps Script manifest so it now ends at the executionApi block

## Testing
- npx clasp push --force *(fails: npm could not determine executable to run in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d65aaa8c8329a026c2c2abba63d1