### PR TITLE
Harden Apps Script CI clasp configuration checks

### DIFF
--- a/.github/workflows/ci-appsscript.yml
+++ b/.github/workflows/ci-appsscript.yml
@@ -37,16 +37,34 @@ jobs:
           CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
         run: |
           if [ -z "$CLASPRC_JSON" ]; then
-            echo "CLASPRC_JSON secret is required"
+            echo "::error::CLASPRC_JSON secret is unavailable. This usually happens on forked workflows; Apps Script deployment requires the repository secret."
             exit 1
           fi
           printf '%s' "$CLASPRC_JSON" > "$HOME/.clasprc.json"
 
       - name: Verify clasp status
-        run: npx clasp status
+        run: |
+          if [ ! -f .clasp.json ]; then
+            echo "::error::Missing .clasp.json. Ensure the Apps Script project configuration is committed."
+            exit 1
+          fi
+          if [ ! -f src/appsscript.json ]; then
+            echo "::error::Missing src/appsscript.json. Did you check out the Apps Script source?"
+            exit 1
+          fi
+          npx clasp status --rootDir src
 
       - name: Push project source
-        run: npx clasp push --force
+        run: |
+          if [ ! -f .clasp.json ]; then
+            echo "::error::Missing .clasp.json. Ensure the Apps Script project configuration is committed."
+            exit 1
+          fi
+          if [ ! -f src/appsscript.json ]; then
+            echo "::error::Missing src/appsscript.json. Did you check out the Apps Script source?"
+            exit 1
+          fi
+          npx clasp push --force --rootDir src
 
       - name: Update existing Web App deployment
         run: node scripts/update-webapp.mjs

--- a/scripts/update-webapp.mjs
+++ b/scripts/update-webapp.mjs
@@ -50,7 +50,7 @@ function selectSingleWebAppDeployment(deployments) {
 
 try {
   console.log('🔍 Inspecting Apps Script deployments...');
-  const deploymentsOutput = run('npx', ['clasp', 'deployments', '--json']);
+  const deploymentsOutput = run('npx', ['clasp', 'deployments', '--json', '--rootDir', 'src']);
   const deployments = parseDeployments(deploymentsOutput);
   const targetDeployment = selectSingleWebAppDeployment(deployments);
   const deploymentId = targetDeployment.deploymentId;
@@ -60,7 +60,7 @@ try {
     console.log(`📄 Description: ${targetDeployment.deploymentConfig.description}`);
   }
 
-  run('npx', ['clasp', 'deploy', '--deploymentId', deploymentId]);
+  run('npx', ['clasp', 'deploy', '--deploymentId', deploymentId, '--rootDir', 'src']);
   console.log('✅ Web App deployment updated successfully.');
 } catch (error) {
   console.error(`❌ ${error.message}`);


### PR DESCRIPTION
## Summary
- fail fast in Apps Script CI when CLASPRC_JSON is unavailable and guard clasp steps with required file checks
- run clasp status/push with explicit --rootDir src to avoid directory drift
- update the webapp deployment helper to pass --rootDir src for all clasp commands

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68e1d9393ff88329a8d0b527ee5487a3